### PR TITLE
Fix missing .py.pyc rules

### DIFF
--- a/lib/localmake_config/localmake_config_proto.pf
+++ b/lib/localmake_config/localmake_config_proto.pf
@@ -290,7 +290,7 @@ capabilities	&Arr{
 }
 dest	&antelope/local/include
 extra_rules	&Literal{
-.SUFFIXES: .SUFFIXES .xpy .xphp .wwwphp
+.SUFFIXES: .SUFFIXES .py .pyc .xpy .xphp .wwwphp
 
 % : %.xpy $(ANTELOPE)/local/data/templates/xpy
 	$(RM) $@
@@ -305,6 +305,10 @@ extra_rules	&Literal{
 .wwwphp.php : $(ANTELOPE)/local/data/templates/wwwphp
 	$(RM) $@
 	cat $(ANTELOPE)/local/data/templates/wwwphp $*.wwwphp > $@
+
+.py.pyc :
+	$(RM) $@
+	$(PYTHON_EXECUTABLE) -c 'import py_compile; py_compile.compile("$<")'
 }
 header	&Literal{
 # DO NOT MODIFY -- Automatically generated file -- DO NOT MODIFY


### PR DESCRIPTION
These went missing in 4e83773adf4023155e59c9df32d7c10ab822fb0d
