### PR TITLE
Add the sts2_5 sensor model to the pf

### DIFF
--- a/bin/usarray/q330_calibration/q330_calibration.pf
+++ b/bin/usarray/q330_calibration/q330_calibration.pf
@@ -6,6 +6,13 @@ sensors &Arr{
         waveform       white 
         amplitude      1        # V = 2.5 amplitude in volts is equal to 5 V / 2 ** amplitude
     }
+    sts2_5 &Arr{
+        duration       7200    # duration <= 16380; q330 limitation
+        settling_time  900
+        trailer_time   900
+        waveform       white
+        amplitude      1        # V = 2.5 amplitude in volts is equal to 5 V / 2 ** amplitude
+    }
     cmg3t &Arr{
         duration       7200    # duration <= 16380; q330 limitation
         settling_time  900 


### PR DESCRIPTION
The sts2_5 sensor model was not in the q330_calibration code base. This was causing stations with sts2_5 sensors installed to be calibrated with the default settings, which don't work. Update the pf to include the settings for sts2_5.
