### PR TITLE
db2loon - rounding error, stamag data

### DIFF
--- a/bin/export/db2loon/db2loon.1
+++ b/bin/export/db2loon/db2loon.1
@@ -287,6 +287,9 @@ two decimal places. Rounding of this field to two decimal places is avoided as r
 day, month and year boundaries introduce inconsistencies between file naming convention and origin
 time as represented in loon file. Truncated digits are insignificant.
 
+PGC is hard-wired as the agency for all phase and amplitude rows as PGC is the only agency providing
+this data. This could potentially be a bug in the future.
+
 .SH AUTHOR
 .nf
 Kent Lindquist, Lindquist Consulting, Inc.

--- a/bin/export/db2loon/db2loon.pf
+++ b/bin/export/db2loon/db2loon.pf
@@ -37,7 +37,7 @@ auth_agencies &Arr{
 	PNSN.*		SEA
 	MTECH.*		BUT
 }
-auth_agency_default	???
+auth_agency_default	PGC
 
 # Formatting pickfiles:
 primary_agency PGC


### PR DESCRIPTION
Fixed rounding error causing seconds field to get rounded to value of 60. Added fix to ensure all available stamag data is transcribed into amplitude row of loon file.
