### PR TITLE
fix libmultiwavelet

### DIFF
--- a/bin/db/dbxcor/Makefile2
+++ b/bin/db/dbxcor/Makefile2
@@ -11,7 +11,7 @@ cxxflags=-g
 ldlibs= -L./SciPlot -L$(XMOTIFLIB) -lseisw -lsciplot -lXm -lXt \
   -lseispp -lperf -lgclgrid -ltks $(TRLIBS) $(X11LIBS) -lseispp
 
-CLEAN =
+SUBDIR=/contrib
 
 ANTELOPEMAKELOCAL = $(ANTELOPE)/contrib/include/antelopemake.local
 

--- a/lib/multiwavelet/libmultiwavelet/MWcoherence.c
+++ b/lib/multiwavelet/libmultiwavelet/MWcoherence.c
@@ -39,7 +39,7 @@ int MWcoherence(MWstack *stack,complex ***z,double **coherence,double *cohb)
         int i,j,k;
         complex **residuals;
 	complex cwork;
-	double coh,z2,r2;
+	double z2,r2;
 	double *z2b,*r2b;  /* accumulated sums for beam */
 	/* These are copies of size variables from stack used
 	to make this more readable. */

--- a/lib/multiwavelet/libmultiwavelet/MWsave_gather.c
+++ b/lib/multiwavelet/libmultiwavelet/MWsave_gather.c
@@ -53,7 +53,7 @@ void MWsave_gather(
 	FILE *fpr,*fpi;
 	int i,j,k;
 	double *t;
-	char *dir;
+	char *dir=NULL;
 
 	allot(double *,t,nt);
 	for(i=0;i<nt;++i) t[i] = t0+dt*((double)i);
@@ -132,7 +132,7 @@ void MWsave_coherence(
 	FILE *fpr,*fpi;
 	int i,j,k;
 	double *t;
-	char *dir;
+	char *dir=NULL;
 
 	allot(double *,t,nt);
 	for(i=0;i<nt;++i) t[i] = t0+dt*((double)i);

--- a/lib/multiwavelet/libmultiwavelet/MWstack.c
+++ b/lib/multiwavelet/libmultiwavelet/MWstack.c
@@ -73,7 +73,6 @@ MWstack *MWextract_stack_window(MWstack *instack,Time_Window *win)
 	int tstart, tend;  /* start and end values(in samples) actually used */
 	int nused;
 	int lag;
-	int ierr;
 	char *message="MWextract_stack_window:  requested window is inconsistent with the stack window";
 
 	MWstack *outstack;
@@ -385,7 +384,6 @@ MWstack *MWrobuststack(complex ***z,
 	double cmag;
 	int iteration;
 	double dzmod,ctest;
-	complex *A;
 
 	/* We scan for the first and last number in timeweight that are nonzero.
 	We need to use a reduced workspace to build stack to avoid biasing statistics

--- a/lib/multiwavelet/libmultiwavelet/apsubs.c
+++ b/lib/multiwavelet/libmultiwavelet/apsubs.c
@@ -417,7 +417,7 @@ int compute_plane_wave_static(MWstation *s,
 	char *method;
 	TTGeometry geometry;
 	TTTime *atime;
-	TTSlow *u0,*u;
+	TTSlow *u0;
 	char refphase[TTPHASE_SIZE];
 	MWSlowness_vector slow;
 	int tresult,uresult;
@@ -486,7 +486,7 @@ int compute_plane_wave_static(MWstation *s,
 	tresult = ttcalc(method,model,phase,0,&geometry,&treturn,&hook);
 	if(tresult)
 	{
-		elog_complain(0,"Error computing travel time from model %s using method %d for station %s\nStatic set to zero\n",
+		elog_complain(0,"Error computing travel time from model %s using method %s for station %s\nStatic set to zero\n",
 			model, method, s->sta);
 		s->plane_wave_static = 0.0;
 		freetbl(treturn,free);
@@ -556,7 +556,7 @@ int set_pwstatics(Arr *stations,
 	if(dbgetv(db,0,"origin.lat",&(source.lat),
 		"origin.lon",&(source.lon),
 		"origin.depth",&(source.z),
-		"origin.time",&(source.time),0) == dbINVALID)
+		"origin.time",&(source.time),NULL) == dbINVALID)
 	{
 		elog_notify(0,"set_pwstatics:  dbgetv error reading origin data\nStatics will all be set to zero\n");
 		orig_error=1;
@@ -849,7 +849,6 @@ int estimate_slowness_vector(
 	int error_code=0;
 	int nsvused;
 	int iteration=0;
-	double dtref;
 	double dutest;
 	int info;
 

--- a/lib/multiwavelet/libmultiwavelet/dbsubs.c
+++ b/lib/multiwavelet/libmultiwavelet/dbsubs.c
@@ -50,7 +50,7 @@ int MWdb_save_slowness_vector(char *phase,
 	double peakcm,
 	Dbptr db)
 {
-	double slo, azimuth, cxx, cyy, cxy;
+	double slo, azimuth;
 	char cmeasure[2];
 
 	slo = hypot(u->ux,u->uy);
@@ -69,8 +69,8 @@ int MWdb_save_slowness_vector(char *phase,
 	}
 
 	if( dbaddv(db,0,"sta",array,
-		"evid",evid,
-		"bankid",bankid,
+		"evid",(long)evid,
+		"bankid",(long)bankid,
 		"phase", phase,
 		"fc",fc,
 		"fwin",fwin,
@@ -85,7 +85,7 @@ int MWdb_save_slowness_vector(char *phase,
 		"ncomp",ncomp,
 		"cohtype",cmeasure,
 		"cohmeas",peakcm,
-		"algorithm","mwap",0) < 0) 
+		"algorithm","mwap",NULL) < 0) 
 	{
 		elog_notify(0,
 			"dbaddv error for mwslow table on evid %d fc=%lf\n",
@@ -136,8 +136,8 @@ int MWdb_save_avgamp(char *array,
 	/* Note algorithm and ampcomp are frozen here.   */
 
 	if( dbaddv(db,0,"sta",array,
-		"evid",evid,
-		"bankid",bankid,
+		"evid",(long)evid,
+		"bankid",(long)bankid,
 		"phase", phase,
 		"fc",fc,
 		"ampcomp",AMPCOMP,
@@ -146,7 +146,7 @@ int MWdb_save_avgamp(char *array,
 		"mwamp",mwamp,
 		"erramp",erramp,
 		"ndgf",ndgf,
-		"algorithm","mwap",0) < 0) 
+		"algorithm","mwap",NULL) < 0) 
 	{
 		elog_notify(0,
 			"dbaddv error for mwavgamp table on evid %d with  fc=%lf\n",
@@ -252,9 +252,9 @@ int MWdb_save_statics(
 		    if( dbaddv(dbsnr,0,
 			"sta",sta,
 			"fc",fc,
-			"bankid",bankid,
+			"bankid",(long)bankid,
 			"phase",phase,
-			"evid",evid,
+			"evid",(long)evid,
 			"nstime",snr->nstime,
 			"netime",snr->netime,
 			"sstime",snr->sstime,
@@ -263,7 +263,7 @@ int MWdb_save_statics(
 			"snrn",snr->ratio_n,
 			"snre",snr->ratio_e,
 			"snr3c",snr->ratio_3c,
-			"algorithm","mwap",0) < 0) 
+			"algorithm","mwap",NULL) < 0) 
 		    {
 			elog_notify(0,"mwtstatic dbaddv error for station %s\n",sta);
 
@@ -300,9 +300,9 @@ int MWdb_save_statics(
 				ierr = dbaddv(dbt,0,
 					"sta",sta,
 					"fc",fc,
-					"bankid",bankid,
+					"bankid",(long)bankid,
 					"phase",phase,
-					"evid",evid,
+					"evid",(long)evid,
 					"time",time,
 					"twin",twin,
 					"wgt",s->current_weight_base,
@@ -312,7 +312,7 @@ int MWdb_save_statics(
 					"errstatic",mws->sigma_t,
 					"ndgf",mws->ndgf,
 					"datum",refelev,
-					"algorithm","mwap",0);
+					"algorithm","mwap",NULL);
 			}
 		    	else
 			{
@@ -320,9 +320,9 @@ int MWdb_save_statics(
 				ierr = dbaddv(dbt,0,
 					"sta",sta,
 					"fc",fc,
-					"bankid",bankid,
+					"bankid",(long)bankid,
 					"phase",phase,
-					"evid",evid,
+					"evid",(long)evid,
 					"time",time,
 					"twin",twin,
 					"wgt",s->current_weight_base,
@@ -333,7 +333,7 @@ int MWdb_save_statics(
 					"ndgf",mws->ndgf,
 					"datum",refelev,
 					"timeres",resid,
-					"algorithm","mwap",0);
+					"algorithm","mwap",NULL);
 			}
 			if(ierr<0)
 			{
@@ -354,16 +354,16 @@ int MWdb_save_statics(
 				"sta",sta,
 				"ampcomp",AMPCOMP,
 				"fc",fc,
-				"bankid",bankid,
+				"bankid",(long)bankid,
 				"phase",phase,
-				"evid",evid,
+				"evid",(long)evid,
 				"time",time,
 				"twin",twin,
 				"wgt",s->current_weight_base,
 				"ndgf",mws->ndgf,
 				"ampstatic",ampdb,
 				"erramp",aerrdb,
-				"algorithm","mwap",0) < 0) 
+				"algorithm","mwap",NULL) < 0) 
 			    {
 				elog_notify(0,"mwtstatic dbaddv error for station %s\n",sta);
 
@@ -419,7 +419,6 @@ int MWdb_save_pm(
 	Dbptr db)
 {
 
-	char *sta;
 	int i;
 	Particle_Motion_Ellipse *pm;
 	Particle_Motion_Error *pmerr;
@@ -467,10 +466,10 @@ int MWdb_save_pm(
 			minema = deg(scoor.theta);
 			if( dbaddv(db,0,
 				"sta",g->sta[i]->sta,
-				"bankid",bankid,
+				"bankid",(long)bankid,
 				"fc",fc,
 				"phase",phase,
-				"evid",evid,
+				"evid",(long)evid,
 				"time",time,
 				"twin",twin,
 				"pmtype","ss",
@@ -487,9 +486,10 @@ int MWdb_save_pm(
 				"majndgf",pmerr->ndgf_major,
 				"minndgf",pmerr->ndgf_minor,
 				"rectndgf",pmerr->ndgf_rect,
-				"algorithm","mwap",0) < 0) 
+				"algorithm","mwap",NULL) < 0) 
 			{
-				elog_notify(0,"dbaddv error in mwpm table for station %s\n",sta);
+				elog_notify(0,"dbaddv error in mwpm table for station %s\n",
+                                        g->sta[i]->sta);
 
 				++errcount;
 			}
@@ -505,10 +505,10 @@ int MWdb_save_pm(
 	minema = deg(scoor.theta);
 	if( dbaddv(db,0,
 		"sta",array,
-		"bankid",bankid,
+		"bankid",(long)bankid,
 		"fc",fc,
 		"phase",phase,
-		"evid",evid,
+		"evid",(long)evid,
 		"time",time,
 		"twin",twin,
 		"pmtype","aa",
@@ -525,7 +525,7 @@ int MWdb_save_pm(
 		"majndgf",pmaerr->ndgf_major,
 		"minndgf",pmaerr->ndgf_minor,
 		"rectndgf",pmaerr->ndgf_rect,
-	   "algorithm","mwap",0) < 0) 
+	   "algorithm","mwap",NULL) < 0) 
 	{
 		elog_notify(0,"dbaddv error saving array average particle motion parameters in mwpm table for evid %d\n",
 			evid);
@@ -559,15 +559,14 @@ Written: April 2002
 
 MWbasis *load_multiwavelets_db(Dbptr db, Pf *pf,int *nwavelets, int *bankid)
 {
-	MWbasis *mwb;
-	int nw;
+	MWbasis *mwb=NULL;
 	char *select_condition;
 	Dbptr dbv;
-	int nrecords;
+	long nrecords;
 	/* These are the attribute in the mwdisc table minus
 	those returned in the argument list */
 
-	int nsamp,foff;
+	long nsamp,foff;
 	double f0,fw;
 	char datatype[4],mworder[4];
 	char fname[128];
@@ -588,14 +587,14 @@ MWbasis *load_multiwavelets_db(Dbptr db, Pf *pf,int *nwavelets, int *bankid)
 		elog_complain(0,"load_multiwavelet_db:  multiple records in mwdisc match the condition %s\nUsing first record found\n",
 			select_condition);
 	dbv.record=0;
-	dbgetv(dbv,0,"bankid",bankid,
+	dbgetv(dbv,0,"bankid",(long)bankid,
 		"nsamp",&nsamp,
 		"nwavelets",nwavelets,
 		"f0",&f0,
 		"fw",&fw,
 		"datatype",datatype,
 		"foff",&foff,
-		"mworder",mworder,0);
+		"mworder",mworder,NULL);
 	if(strcmp(datatype,"t4"))
 		elog_die(0,"multiwavelets must be in t4 binary form\n");
 	if(strcmp(mworder,"ti") || strcmp(mworder,"ts") )
@@ -645,16 +644,16 @@ MWbasis *load_multiwavelets_db(Dbptr db, Pf *pf,int *nwavelets, int *bankid)
 				nr=fread(mwb[i].r,sizeof(float),nsamp,fp);
 				ni=fread(mwb[i].i,sizeof(float),nsamp,fp);
 				if( (nr!=nsamp) || (ni!=nsamp) )
-					elog_die(0,"read error on file %s while reading wavelet %d\nRead %d real and %d imaginary samples while expecting %d\n",
+					elog_die(0,"read error on file %s while reading wavelet %d\nRead %d real and %d imaginary samples while expecting %ld\n",
 						fname,i,
 						nr,ni,nsamp);
 			}
 		}
+	        fclose(fp);
 	}
 	else
 		elog_die(0,"load_multiwavelet_db: don't know how to read mworder %s\nCurrently support only ti and ts\n",
 			mworder);
 	
-	fclose(fp);
 	return(mwb);
 }

--- a/lib/multiwavelet/libmultiwavelet/decimate.c
+++ b/lib/multiwavelet/libmultiwavelet/decimate.c
@@ -54,7 +54,7 @@ Tbl **define_decimation(Pf *pf, int *nbands)
 }
 
 /* This routine looks at a sequence of css response files passed
-through the dec_stages list of file names, reads these response
+through the decdef tbl of file names, reads these response
 files, and stores the description of them in a series of output 
 Tbls.  
 arguments:
@@ -81,7 +81,6 @@ int read_dec_files (Tbl *decdef, int *dec_fac, Tbl **decimators)
 	Response *rsp;
 	char string[512];
 	FILE *file;
-	char **dec_stages;
 
 	FIR_decimation *decptr;
  	Response *resp;
@@ -137,12 +136,12 @@ int read_dec_files (Tbl *decdef, int *dec_fac, Tbl **decimators)
 			get_response_stage_fir_ncoefs (rsp, j, &srate, &dec_factor, &nnum, &nden);
 			if (nden > 1) {
 				elog_notify(0, "read_dec_files: Dont know how to do IIR filters (%s).\n",
-										dec_stages[i]);
+                                        decfile);
 				return (0);
 			}
 			if (nnum < 1) {
 				elog_notify(0, "read_dec_files: No numerator terms (%s).\n",
-										dec_stages[i]);
+                                        decfile);
 				return (0);
 			}
 			ok=1;
@@ -150,7 +149,7 @@ int read_dec_files (Tbl *decdef, int *dec_fac, Tbl **decimators)
 		}
 		if (!ok) {
 			elog_notify(0, "read_dec_files: no fir stage on file '%s'.\n",
-							dec_stages[i]);
+                                        decfile);
 			return (0);
 		}
 		for (j=0; j<n; j++) {
@@ -170,12 +169,10 @@ int read_dec_files (Tbl *decdef, int *dec_fac, Tbl **decimators)
 
 	for (i=0; i<n; i++) {
 		Response_group *gpi;
-		int dec_factor, nnum, nden, n2;
+		int dec_factor, nnum, nden;
 		double srate;
 		double *coefsi, *coefs_err;
 		double *coefdi, *coefd_err;
-		float *cfs;
-		int *numb, *decf;
 
 		decptr = (FIR_decimation *) malloc(sizeof(FIR_decimation));
 		if(decptr == NULL)

--- a/lib/multiwavelet/libmultiwavelet/mwavelet.c
+++ b/lib/multiwavelet/libmultiwavelet/mwavelet.c
@@ -119,7 +119,7 @@ Arr *tr_mwtransform(
 {
 	Dbptr dbgrp;
 	Tbl *sortkeys,*grpkeys;
-	int nrows,nchan;
+	long nrows;
 	Dbptr dbbundle;
 	double rwinstart, rwinend;  /* relative start and end times in s*/
 	double trace_start, trace_end;  /* trace start and end absolute times */
@@ -130,10 +130,9 @@ Arr *tr_mwtransform(
 	double *atime;
 
 	Trsample *trdata;
-	int nsamp;
+	long nsamp;
 	double samprate,si;
 
-	int is, ie, nrec;
 	int istart; 
 	int points_to_process;
 	MWtrace ***mwt; 
@@ -170,16 +169,16 @@ Arr *tr_mwtransform(
 
 	for(dbgrp.record=0;dbgrp.record<nrows;++dbgrp.record)
 	{
-		int is,ie,nrec,irec;
+		long is,ie,nrec;
 		double reclen;
 		double s1, s2, tsegment;
 		if(dbgetv(dbgrp,0,
 			"sta",sta,
 			"chan",chan,
 			"bundle",&dbbundle,
-			0) == dbINVALID)
+			NULL) == dbINVALID)
 		{
-			  elog_complain(0,"dbgetv error while reading record %d of sta/chan grouping table\nData loss likely\n",
+			  elog_complain(0,"dbgetv error while reading record %ld of sta/chan grouping table\nData loss likely\n",
 					dbgrp.record);
 			  continue;
 		}
@@ -209,7 +208,7 @@ fprintf(stderr,"DEBUG:  entered gap loop for %s:%s\n",sta,chan);
 				/*I intentionally don't trap errors here.
 				It should never happen.*/
 				dbgetv(tr,0,"time",&trace_start,
-					"endtime",&trace_end,0);
+					"endtime",&trace_end,NULL);
 				if(trace_end <= swtime) continue;
 				if(trace_start >= ewtime) continue;
 				if(trace_start < swtime)
@@ -240,7 +239,7 @@ fprintf(stderr,"DEBUG:  entered gap loop for %s:%s\n",sta,chan);
 				"endtime", &trace_end,
 				"nsamp",&nsamp,
 				"samprate",&samprate,
-				"data",&(trdata),0);
+				"data",&(trdata),NULL);
 
 		si = 1.0/samprate;
 		/*We want to be careful to keep times accurate to 
@@ -655,7 +654,7 @@ Written:  Sept. 1999
 MWgather *MWgather_transformation(MWgather *ingath,double *u)
 {
 	MWgather *gather;
-	int i,j,ii,nz;
+	int i,nz;
 	complex *z1, *z2, *z3;  /*work vectors holds transformed seismograms */
 	int nsta,nz_sta;
 	complex ztmp;
@@ -1316,6 +1315,9 @@ int idbug, jdbug;
 
 	allot(complex *,A,(g->nsta)*(w.length));
 	allot(float *,svalue,MIN(g->nsta,w.length));
+        /* These are not used - explicitly set to NULL as a style thing */
+        U=NULL;
+        Vt=NULL;
 	for(i=0,ii=0;i<(g->nsta);++i)
 	{
 		if((g->x3[i]) == NULL) continue;
@@ -1442,7 +1444,6 @@ void compute_optimal_lag(MWgather **g,int nwavelets,double timeref,
 	MW_scalar_statistics stats; 
 	float peak_semb;
 	int lag_at_peak;
-	char *array_name;
 	int *window_error;
 
 
@@ -1842,7 +1843,7 @@ int compute_mw_arrival_times(MWgather **g,int nwavelets,double timeref,
 	double *avgamp, double *amperr, int *ampndgf)
 {
 	int nsta,nsta_used,nsta_test;
-	int i,j,ii;
+	int i,j;
 	double U[9];  /* transformation matrix */
 	MWgather **trans_gath;
 	double *current_moveout;  /* initially copy of moveout, but changes
@@ -1851,6 +1852,8 @@ int compute_mw_arrival_times(MWgather **g,int nwavelets,double timeref,
 			station.  Stored in a parallel array to 
 			moveout and elements of MWgather */
 	complex *A,*Usvd,*Vt;  /* Usvd and Vt are not actually accessed at present*/
+        Usvd=NULL;
+        Vt=NULL;
 	float *svalues,*sv1;  /* svalues is a work space, sv1 stores largest
 				singular value for each wavelet */
 	complex *eigenvectors;  /* Eigenvectors for each wavelet are 
@@ -2216,11 +2219,12 @@ void compute_mw_particle_motion(MWgather **g,int nwavelets,double timeref,
 {
 	int nsta,nsta_used,nrows,info;
 	int i,j,ii,jj;
-	MWgather **trans_gath;
 	int *alllags;  /* base lag computed from moveout for each 
 			station.  Stored in a parallel array to 
 			moveout and elements of MWgather */
 	complex *A,*U,*Vt;  /* U and Vt are not actually accessed at present*/
+        U=NULL;
+        Vt=NULL;
 	float *svalues;  /* singular value work vector */
 	float *weights;  /* Holds row of weights */
 	Particle_Motion_Ellipse *ematrix;  /* this is set to be a 

--- a/lib/multiwavelet/libmultiwavelet/mwaveletsubs.c
+++ b/lib/multiwavelet/libmultiwavelet/mwaveletsubs.c
@@ -32,7 +32,7 @@ MWbasis  *load_multiwavelets_pf(Pf *pf,int *nwavelets)
 			nsamples*(*nwavelets),*nwavelets,nsamples,nrows);
 	mw = (MWbasis *)calloc(*nwavelets, sizeof(MWbasis));
 	if(mw == NULL)
-		elog_die(0,"Cannot alloc %d multiwavelet structures\n",nwavelets);
+		elog_die(0,"Cannot alloc %d multiwavelet structures\n",*nwavelets);
 	for(i=0,k=0;i<(*nwavelets);++i)
 	{
 		mw[i].r = calloc(nsamples,sizeof(float));
@@ -163,7 +163,7 @@ MWtrace **MWtransform(float *trace, double dt, double starttime, int nsamples,
 	MWtrace **allmw;  /* working matrix variable */
 	int i,j;
 	int ii,k;
-	double stime,etime;  /* start end times of working trace */
+	double stime;  /* start end times of working trace */
 	int n;  /* samples in current trace */
 	double dtnew;  /* sample interval of current band */
 	double dtprevious,stprevious;

--- a/lib/multiwavelet/libmultiwavelet/polarization.c
+++ b/lib/multiwavelet/libmultiwavelet/polarization.c
@@ -35,7 +35,7 @@ Particle_Motion_Ellipse compute_particle_motion(complex x,
 	double a,b;
 	double phi1,phi2;
 	double x1[3],x2[3];
-	double nrmx1,nrmx2,xmaj,xmin;
+	double nrmx1,nrmx2;
 	Particle_Motion_Ellipse e;
 
 
@@ -292,7 +292,7 @@ void pmvector_average(Particle_Motion_Ellipse *pmv, int n,
 	because a projection is always <= original */
 	for(i=0;i<n;++i)
 	{
-		double minor_nrm,major_nrm;
+		double minor_nrm;
 		minor_nrm = dnrm2(3,v+i*3,1);
 		/* Not needed because the major axis vector
 		was previously normalized to unit length 

--- a/lib/multiwavelet/libmultiwavelet/polarization.c
+++ b/lib/multiwavelet/libmultiwavelet/polarization.c
@@ -1,4 +1,5 @@
 #include <math.h>
+#include <float.h>
 #include "stock.h"
 #include "perf.h"
 #include "arrays.h"
@@ -158,7 +159,14 @@ void pmvector_average(Particle_Motion_Ellipse *pmv, int n,
 	M_estimator_double_n_vector(v,3,n,
 		IQ_SCALE_RELATIVE,PM_MINSCALE_MAJOR,avg,weight);
 	nrm_major = dnrm2(3,avg,1);
-	for(i=0;i<3;++i) pmavg->major[i] = avg[i]/nrm_major;
+	for(i=0;i<3;++i) 
+	{
+	    /* Needed to avoid random NaN */
+	    if(nrm_major<FLT_EPSILON)
+	    	pmavg->major[i] = avg[i];
+	    else
+		pmavg->major[i] = avg[i]/nrm_major;
+	}
 
 	/* Error estimates are computed completely differently here from
 	that described in Bear and Pavlis (1999).  Rather than use a 

--- a/lib/multiwavelet/libmultiwavelet/stations.c
+++ b/lib/multiwavelet/libmultiwavelet/stations.c
@@ -13,7 +13,6 @@ Written:  August 19, 1998 +
 /* small companion initializer to function below */
 void initialize_MWstation(MWstation *s,int nbands)
 {
-	int i;
 	s->sta = NULL;
 	s->lat = 0.0;
 	s->lon = 0.0;
@@ -254,11 +253,10 @@ int load_station_geometry(Dbptr db, Arr *a, double time)
 	Tbl *t;
 	char *key;
 	int yrday;
-	Dbptr dbscr;
 	static Hook *hook=NULL;
 	Tbl *match_tbl;
 	MWstation *s;
-	int ondate,offdate;
+	long ondate,offdate;
 	char refsta[10];  /*This is used as input buffer that
 				is duped to store in each s object*/
 	char refsta0[10];  /* Used for comparison to guarantee there
@@ -273,10 +271,10 @@ int load_station_geometry(Dbptr db, Arr *a, double time)
 
 	for(i=0,nset=0;i<maxtbl(t);i++)
 	{
-		int nmatch;
+		long nmatch;
 		key = gettbl(t,i);
 		s = (MWstation *)getarr(a,key);
-		dbputv(dbs,0,"sta",s->sta,0);
+		dbputv(dbs,0,"sta",s->sta,NULL);
 		nmatch = dbmatches(dbs,db,0,0,&hook,&match_tbl);
 		if(nmatch == dbINVALID)
 			elog_die(0,"dbmatches error looking for entries for station %s\n",s->sta);
@@ -300,9 +298,9 @@ int load_station_geometry(Dbptr db, Arr *a, double time)
 			{
 				for(j=0;j<maxtbl(match_tbl);j++)
 				{
-					db.record = (int)gettbl(match_tbl,j);
+					db.record = (long)gettbl(match_tbl,j);
 					if(dbgetv(db,0,"ondate",&ondate,
-							"offdate",&offdate,0)
+							"offdate",&offdate,NULL)
 						== dbINVALID)
 					{
 						elog_notify(0,"load_station_geometry:  dbgetv error while searching for ondate/offdate match for station %s\nBlundering on\n", 
@@ -322,9 +320,9 @@ int load_station_geometry(Dbptr db, Arr *a, double time)
 				"dnorth",&(s->dnorth),
 				"deast",&(s->deast),
 				"refsta",refsta,
-				0) == dbINVALID)
+				NULL) == dbINVALID)
 			{
-				elog_notify(0,"load_station_geometry:  dbgetv error reading record %d for station %s in site table\nStation deleted from list\n",
+				elog_notify(0,"load_station_geometry:  dbgetv error reading record %ld for station %s in site table\nStation deleted from list\n",
 					db.record,s->sta);
 				delarr(a,s->sta);
 				free_MWstation(s);
@@ -383,7 +381,7 @@ int load_initial_statics(Pf *pf, Arr *a)
 	for(i=0,nset=0;i<maxtbl(t);i++)
 	{
 		line = gettbl(t,i);
-		if((sscanf(line,"%s %lf %lf",sta,&statics)) != 2)
+		if((sscanf(line,"%s %lf",sta,&statics)) != 2)
 		{
 			elog_notify(0,"Syntax error reading line from initial_statics Tbl\nOffending line->%s\n",
 				line);

--- a/lib/multiwavelet/libmultiwavelet/statistics_subs.c
+++ b/lib/multiwavelet/libmultiwavelet/statistics_subs.c
@@ -527,7 +527,7 @@ void M_estimator_double_n_vector(double *v,
 		scale = compute_nvector_scale(residuals,n,nv,row);
 		if(scale < fminsc) scale = fminsc;
 		for(i=0;i<n;++i) delta_mean[i] = 0.0;
-		for(j=0;j<nv;++j)
+		for(j=0,sum_weights=0.0;j<nv;++j)
 		{
 			dcopy(n,residuals+j*n,1,col,1);
 			dvmag = dnrm2(n,col,1);
@@ -555,7 +555,7 @@ void M_estimator_double_n_vector(double *v,
 		free(col);
 		free(row);
 		free(delta_mean);
-		free(delta_mean);
+                free(residuals);
 		return;
 	}
 	/* This is the value of beta recommended by chave and thomson, 1987,
@@ -589,7 +589,6 @@ void M_estimator_double_n_vector(double *v,
 	free(col);
 	free(row);
 	free(delta_mean);
-	free(delta_mean);
 	free(residuals);
 }
 /* Delete one jackknife error estimator.  Uses simple formula 
@@ -609,7 +608,6 @@ Author:  Gary Pavlis
 double d1_jack_err(int n, double *x)
 {
 	double *pval;
-	double xbardot;
 	double jkerror;
 	double mean;
 	int i,j;

--- a/lib/multiwavelet/libmultiwavelet/statistics_subs.c
+++ b/lib/multiwavelet/libmultiwavelet/statistics_subs.c
@@ -310,6 +310,9 @@ float M_estimator_float(float *x,int nx,int mode,double minscale)
 	stats=MW_calc_statistics_float(wtres,nx);
 	fmean = stats.median;
 	if(IQ_SCALE_RELATIVE)
+	    if(fmean<FLT_EPSILON)
+		fminsc = minscale;
+	    else
 		fminsc = fmean*((float)minscale);
 	else
 		fminsc = (float)minscale;
@@ -515,6 +518,9 @@ void M_estimator_double_n_vector(double *v,
 	for(j=0;j<nv;++j) weight[j] = 1.0; /* done to make sure scale
 					is computed correctly on first pass*/
 	if(mode==IQ_SCALE_RELATIVE)
+	    if(vmag<FLT_EPSILON)
+		fminsc= minscale;
+	    else
 		fminsc = vmag*minscale;
 	else
 		fminsc = minscale;

--- a/lib/multiwavelet/libmultiwavelet/trace_subs.c
+++ b/lib/multiwavelet/libmultiwavelet/trace_subs.c
@@ -41,8 +41,8 @@ November 2000
 
 int mwap_load_sta(Dbptr db, Dbptr tr, double s, double e, char *sta)
 {
-	int nsamp;
-	double time, endtime,samprate,calib;
+	long nsamp;
+	double samprate,calib;
 	double hang,vang,edepth;
 	char chan[10];
 	static Hook *hook=NULL;
@@ -52,7 +52,7 @@ int mwap_load_sta(Dbptr db, Dbptr tr, double s, double e, char *sta)
 	int nmatch;
 	int i,ierr;
         float *data;
-        int datasz;
+        long datasz;
         double t0,t1;
 	char net[4]="MW";   /* This is a required key on trace table so 
 				we just set it to a value */
@@ -63,16 +63,16 @@ int mwap_load_sta(Dbptr db, Dbptr tr, double s, double e, char *sta)
 	if(dbt.record == dbINVALID) return(dbINVALID);
 	dbk = dblookup(db,0,"wfdisc",0,0);
 	dbk.record = dbSCRATCH;
-	dbputv(dbk,0,"sta",sta,"time",s,"endtime",e,0);
+	dbputv(dbk,0,"sta",sta,"time",s,"endtime",e,NULL);
 
-	pattern = strtbl("sta","time::endtime",0);
+	pattern = strtbl("sta","time::endtime",0L);
 	nmatch = dbmatches(dbk,dbt,&pattern,&pattern,&hook,&matches);
 	if( (nmatch == dbINVALID) || (nmatch == 0) )return(nmatch);
 	for(i=0,ntrread=0;i<maxtbl(matches);++i)
 	{
 		data = NULL;
 		datasz = 0;
-		dbt.record = (int)gettbl(matches,i);
+		dbt.record = (long)gettbl(matches,i);
 		ierr = trgetwf(dbt,0,&data,&datasz,s,e,&t0,&t1,&nsamp,0,0);
 		if(ierr)
 		{
@@ -90,7 +90,7 @@ int mwap_load_sta(Dbptr db, Dbptr tr, double s, double e, char *sta)
 				"hang",&hang,
 				"vang",&vang,
 				"edepth",&edepth,
-				0);
+				NULL);
 		if(ierr)  
 		{
 		   elog_notify(0,
@@ -110,7 +110,7 @@ int mwap_load_sta(Dbptr db, Dbptr tr, double s, double e, char *sta)
 				"data",data,
 				"hang",hang,
 				"vang",vang,
-				0);
+				NULL);
 		if(ierr<0)
 		{
 			elog_notify(0,"Error appending to trace table for %s:%s at %s\nProbably data loss and associated memory leak\n",
@@ -162,8 +162,6 @@ Dbptr mwap_readdata(Dbptr db, Arr *arrivals,
 	double wstart, wend;  /* relative window positions */
 
 	Dbptr tr;  /* trace data base pointer */
-	Dbptr dbwf; 
-	char ss[30];
 	int nsta;  /* count of number of stations from subset group */
 	char *sta;  /* holds station name */
 	Tbl *t;  /* keysarr tbl of arrivals */
@@ -232,7 +230,7 @@ Author:  Gary Pavlis
 int free_noncardinal_traces(Dbptr tr)
 {
 	Dbptr db;
-	int nrec;
+	long nrec;
 	char chan[20];
 	char *cardinal[3]={ EW, NS, VERTICAL };
 	int i,found;
@@ -242,7 +240,7 @@ int free_noncardinal_traces(Dbptr tr)
 
 	for(db.record=0;db.record<nrec;++db.record)
 	{
-		dbgetv(db,0,"chan",chan,0);
+		dbgetv(db,0,"chan",chan,NULL);
 		for(found=0,i=0;i<3;++i)
 		{
 			if(!strcmp(chan,cardinal[i])) 

--- a/lib/multiwavelet/libmultiwavelet/ttsubs.c
+++ b/lib/multiwavelet/libmultiwavelet/ttsubs.c
@@ -62,7 +62,7 @@ int MWget_model_tt_slow(Arr *stations,
 	char *method;
 	TTGeometry geometry;
 	TTTime *atime;
-	TTSlow *u0,*u;
+	TTSlow *u0;
 	Tbl *treturn=NULL,*ureturn=NULL;
 	int error_count=0;
 	double *twork;
@@ -72,7 +72,7 @@ int MWget_model_tt_slow(Arr *stations,
 	if(dbgetv(db,0,"origin.lat",&(geometry.source.lat),
 		"origin.lon",&(geometry.source.lon),
 		"origin.depth",&(geometry.source.z),
-		"origin.time",&(geometry.source.time),0) == dbINVALID)
+		"origin.time",&(geometry.source.time),NULL) == dbINVALID)
 	{
 		elog_complain(0,"MWget_model_tt_slow:  dbgetv error reading origin data\nCannot compute theoretical arrival times and slowness\n");
 		return(-1);	

--- a/lib/multiwavelet/libmultiwavelet/utilities.c
+++ b/lib/multiwavelet/libmultiwavelet/utilities.c
@@ -35,7 +35,6 @@ void check_required_pf(Pf *pf)
 	int i,j,nitems;
 	int itest, ilowcheck, ihighcheck;
 	double dtest, dlowcheck, dhighcheck;
-	int bool;
 	char *line;
 	char *ctest;
 	char name[50];
@@ -361,7 +360,7 @@ int irregular_to_regular_interpolate(double *x1, double *y1, int n1,
 		}
 		while (istart<0);
 	}
-	for(i=istart,i1=i1start;i<ny,i1<n1-1;++i1)
+	for(i=istart,i1=i1start;(i<ny)||(i1<n1-1);++i1)
 	{
 		if(x1[i1+1]==x1[i1])continue;
 		grad = (y1[i1+1]-y1[i1])/(x1[i1+1]-x1[i1]);


### PR DESCRIPTION
The multiwavelet library was never passed through the 64 bit conversion.  These changes fix clear bugs that would make anything using it break.  Also uncovered a few minor bugs in writing wrappers for this code in C++.   Those will appear later.