### PR TITLE
add new plot library

### DIFF
--- a/bin/db/dbxcor/SciPlot/Makefile
+++ b/bin/db/dbxcor/SciPlot/Makefile
@@ -2,7 +2,7 @@ LIB=libsciplot.a
 
 cflags = -I$(XMOTIFINCLUDE)
 
-ANTELOPEMAKELOCAL = $(ANTELOPE)/local/include/antelopemake.local
+ANTELOPEMAKELOCAL = $(ANTELOPE)/contrib/include/antelopemake.local
 
 SUBDIR=/contrib
 include $(ANTELOPEMAKE)

--- a/lib/graphics/libseiswplot/BasicSeisPlot.h
+++ b/lib/graphics/libseiswplot/BasicSeisPlot.h
@@ -1,0 +1,27 @@
+#ifndef _BASICSEISPLOT_H
+#define _BASICSEISPLOT_H
+#include "ensemble.h"
+namespace SEISPP
+{
+using namespace std;
+using namespace SEISPP;
+/*! Abstract base class for family of seismic plotting objects.
+
+  This provides a pure virtual base for seismic plotting centered
+  around the SEISPP library of data objects.  
+  
+  \author Gary L Pavlis
+  */
+
+class BasicSeisPlot
+{
+    public:
+        /* Support 3c seismograms only when this is set true */
+        bool ThreeComponentMode;  
+        virtual void plot(TimeSeriesEnsemble& d,bool block)=0;
+        virtual void plot(ThreeComponentEnsemble& d,bool block)=0;
+        virtual void plot(TimeSeries& d,bool block)=0;
+        virtual void plot(ThreeComponentSeismogram& d,bool block)=0;
+};
+}
+#endif

--- a/lib/graphics/libseiswplot/Makefile2
+++ b/lib/graphics/libseiswplot/Makefile2
@@ -1,0 +1,24 @@
+LIB=libseisppplot.a
+PF=SeismicPlot.pf
+# DLIB=$(LIB:.a=$(DSUFFIX))
+# BUNDLE=$(LIB:.a=.bundle) 
+INCLUDE=BasicSeisPlot.h SeismicPlot.h TraceEditPlot.h TimeWindowPicker.h
+SUBDIR=/contrib
+
+#Needed eventually
+#MAN3=
+
+ccflags=$(XMOTIFINCLUDE)
+
+ANTELOPEMAKELOCAL = $(ANTELOPE)/contrib/include/antelopemake.local
+
+include $(ANTELOPEMAKE)  
+include $(ANTELOPEMAKELOCAL)
+
+CXXFLAGS += -I$(XMOTIFINCLUDE) -I$(BOOSTINCLUDE)
+
+OBJS=   SeismicPlot.o TimeWindowPicker.o
+$(LIB) : $(OBJS)
+	$(RM) $@
+	$(CXXAR) $(CXXARFLAGS) $@ $(OBJS)  
+	$(RANLIB) $@

--- a/lib/graphics/libseiswplot/SeismicPlot.cc
+++ b/lib/graphics/libseiswplot/SeismicPlot.cc
@@ -1,0 +1,510 @@
+// Needed only for debug.  Eventually should go
+#include <iostream>
+#include <X11/Xthreads.h>
+#include <boost/thread/thread.hpp>
+#include <boost/bind.hpp>
+#include "SeismicPlot.h"
+/* This is needed here because this class is also defined in this file.  
+   This was necessary to allow both classes to use the BuildMenu procedure. */
+#include "TraceEditPlot.h"
+using namespace std;
+using namespace SEISPP;
+#define APP_CLASS "seismicplot"
+// this constant cloned from dbxcor
+#define MAINFORM_GRID_CNT 15
+/* This is cloned from dbxcor.  It is used as a compact data structure to sent to 
+   a procedure immediately below (BuildMenu) that constructs a widget based on this specification*/
+typedef struct _menu_item
+{
+        char              *label;          /* the label for the item */
+        WidgetClass       *class1;          /* pushbutton, label, separator... */
+        char               mnemonic;       /* mnemonic; NULL if none */
+        char              *accelerator;    /* accelerator; NULL if none */
+        char              *accel_text;     /* to be converted to compound string */
+        void             (*callback)(Widget,void *,void *);    /* routine to call; NULL if none */
+        XtPointer          callback_data;  /* client_data for callback() */
+        Widget           w;
+        struct _menu_item *subitems;       /* pullright menu items, if not NULL */
+} MenuItem;
+
+/* Pulldown menus are built from cascade buttons, so this function
+** also includes pullright menus. Create the menu, the cascade button
+** that owns the menu, and then the submenu items.
+
+This is a copy from dbxcor.  I think it originally came from some X cookbook. 
+*/
+Widget BuildMenu (Widget parent, int menu_type, char *menu_title, char menu_mnemonic,
+                  Boolean tear_off, MenuItem *items)
+{
+        Widget   menu, cascade, widget;
+        int      i;
+        XmString str;
+        Arg      args[8];
+        int      n;
+
+        if (menu_type == XmMENU_PULLDOWN)
+                menu = XmCreatePulldownMenu (parent,(char *) "_pulldown", NULL, 0);
+        else {
+                n = 0;
+                XtSetArg (args[n], XmNpopupEnabled, XmPOPUP_AUTOMATIC_RECURSIVE); n++;
+                menu = XmCreatePopupMenu (parent, (char *) "_popup", args, n);
+        }
+
+        if (tear_off)
+                XtVaSetValues (menu, XmNtearOffModel, XmTEAR_OFF_ENABLED, NULL);
+
+        if (menu_type == XmMENU_PULLDOWN) {
+                str = XmStringCreateLocalized (menu_title);
+                n = 0;
+                XtSetArg (args[n], XmNsubMenuId, menu); n++;
+                XtSetArg (args[n], XmNlabelString, str); n++;
+                XtSetArg (args[n], XmNmnemonic, menu_mnemonic); n++;
+                cascade = XmCreateCascadeButtonGadget (parent, menu_title, args, n);
+                XtManageChild (cascade);
+                XmStringFree (str);
+        }
+
+        /* Now add the menu items */
+        for (i = 0; items[i].label != NULL; i++) {
+                /* If subitems exist, create the pull-right menu by calling this
+                ** function recursively. Since the function returns a cascade
+                ** button, the widget returned is used..
+                */
+
+                if (items[i].subitems) {
+                        widget = BuildMenu (menu, XmMENU_PULLDOWN, items[i].label,
+                                                items[i].mnemonic, tear_off, items[i].subitems);
+			items[i].w=widget;
+                } else {
+                        widget = XtVaCreateManagedWidget (items[i].label, *items[i].class1, menu, NULL);
+                        items[i].w=widget;
+                }
+
+                /* Whether the item is a real item or a cascade button with a
+                ** menu, it can still have a mnemonic.
+                */
+                if (items[i].mnemonic)
+                        XtVaSetValues (widget, XmNmnemonic, items[i].mnemonic, NULL);
+
+                /* any item can have an accelerator, except cascade menus. But,
+                ** we don't worry about that; we know better in our declarations.
+                */
+                if (items[i].accelerator) {
+                        str = XmStringCreateLocalized (items[i].accel_text);
+
+                        XtVaSetValues (widget, XmNaccelerator, items[i].accelerator, XmNacceleratorText,
+                                       str, NULL);
+                        XmStringFree (str);
+                }
+                if (items[i].callback) {
+                        String resource;
+
+                        if (XmIsToggleButton(widget) || XmIsToggleButtonGadget(widget))
+                                resource = XmNvalueChangedCallback;
+                        else
+                                resource = XmNactivateCallback;
+
+                        XtAddCallback(widget, resource, items[i].callback,(XtPointer) items[i].callback_data);
+                }
+        }
+
+        return (menu_type == XmMENU_PULLDOWN) ? cascade : menu ;
+}
+void continue_callback(Widget w, XtPointer client_data, XtPointer call_data)
+{
+    SeismicPlot *plot_handle=reinterpret_cast<SeismicPlot *>(client_data);
+    plot_handle->ExitDisplay();
+}
+/* This is a private method used by both constructors.  It provides
+   a convenient way to standardize this without requiring a copy
+   operation which would be deadly here. */
+void SeismicPlot::initialize_widgets(Metadata& md)
+{
+    try{
+        ThreeComponentMode=md.get_bool("ThreeComponentMode");
+        comp0=NULL;  comp1=NULL;  comp2=NULL;
+        argc=1;
+        argv[0]=strdup("SeismicPlotWidget");
+        XtSetLanguageProc(NULL, NULL, NULL);
+        XtToolkitThreadInitialize();
+        toplevel = XtVaAppInitialize(&AppContext, (char *)"seismicplot",NULL,0,
+                                &argc,argv, NULL,NULL);
+        main_w=XmCreateForm(toplevel,(char *) "seismicplot",NULL,0);
+        EventLoopIsActive=false;
+        menu_bar=XmCreateMenuBar(main_w,(char *)"menuBar",NULL,0);
+        XtVaSetValues (menu_bar, XmNtopAttachment,  XmATTACH_FORM, XmNleftAttachment, XmATTACH_FORM,
+                        XmNrightAttachment, XmATTACH_FORM, NULL);
+        MenuItem file_menu[]={
+            {(char *) "Exit Event Loop",&xmPushButtonGadgetClass,'x',
+                (char *)"<Key>X",(char *)"X",
+                continue_callback,this,NULL,(MenuItem *)NULL},
+                 {NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL}};
+        menu_file=BuildMenu(menu_bar,XmMENU_PULLDOWN,
+                (char *)"Control",'C',false,file_menu);
+        XtManageChild(menu_bar);
+        /* We create a secondary form which will hold the 3 seismic components within it in 
+           a paned window.  We'll create that pair now one after the other. */
+        Arg args[4];
+        int n=0;
+        XtSetArg(args[n],XmNfractionBase,MAINFORM_GRID_CNT); n++;
+        slrc = XmCreateForm(main_w, (char *) "form", args,n);
+        XtVaSetValues (slrc,
+                 XmNleftAttachment, XmATTACH_FORM,
+		 XmNrightAttachment, XmATTACH_FORM,
+                 XmNtopAttachment,  XmATTACH_WIDGET,
+		 XmNtopWidget, menu_bar,
+                 XmNbottomAttachment, XmATTACH_FORM,
+                 NULL);
+        XtManageChild(slrc);
+        paned_win=XtVaCreateWidget((char *)"pane",
+        	xmPanedWindowWidgetClass,slrc,
+        	XmNorientation,			XmVERTICAL,
+        	XmNseparatorOn,			True,
+        	XmNtopAttachment,		 XmATTACH_POSITION,
+        	XmNtopPosition,		 	0,
+        	XmNleftAttachment,		 XmATTACH_POSITION,
+        	XmNleftPosition,		 0,
+        	XmNrightAttachment,		 XmATTACH_POSITION,
+        	XmNrightPosition,		 MAINFORM_GRID_CNT,
+        	XmNbottomAttachment,		 XmATTACH_POSITION,
+        	XmNbottomPosition,		MAINFORM_GRID_CNT-1,
+        	NULL);
+        XtManageChild(paned_win);
+        /* Now build empty seisw widgets */
+        n=0;
+        XtSetArg(args[n],(char *) ExmNdisplayOnly,1); n++;
+        XtSetArg(args[n],(char *) ExmNzoomFactor,100); n++;
+        XtSetArg(args[n],XmNpaneMaximum,1000); n++;
+        XtSetArg(args[n],XmNpaneMinimum,100); n++;
+        seisw[0]=ExmCreateSeisw(paned_win,(char *)"Seisw0",args,n);
+        XtManageChild(seisw[0]);
+        if(ThreeComponentMode)
+        {
+            seisw[1]=ExmCreateSeisw(paned_win,(char *)"Seisw1",args,n);
+            XtManageChild(seisw[1]);
+            seisw[2]=ExmCreateSeisw(paned_win,(char *)"Seisw2",args,n);
+            XtManageChild(seisw[2]);
+        }
+        else
+        {
+            seisw[1]=NULL;
+            seisw[2]=NULL;
+        }
+        XtManageChild(main_w);
+        XtRealizeWidget(toplevel);
+    } catch (...){throw;}
+}
+/* Default constructor gets its parameter information from the
+standard antelope parameter file location under a frozen name 
+(SeismicPlot.pf).  */
+SeismicPlot::SeismicPlot()
+{
+    cerr << "Entered default constructor"<<endl;
+    Pf *pf;
+    const string pfglobal_name("SeismicPlot");
+    if(pfread(const_cast<char *>(pfglobal_name.c_str()),&pf))
+        throw SeisppError("SeismicPlot constructor:  pfread failed for "
+                + pfglobal_name);
+    try {
+	Metadata md(pf);
+	pffree(pf);
+        this->initialize_widgets(md);
+        EventLoopIsActive=false;
+        block_till_exit_pushed=true;   // default 
+    } catch (...) {throw;}
+}
+/* Construct from a Metadata object. */
+SeismicPlot::SeismicPlot(Metadata& md) : Metadata(md)
+{
+    try {
+        this->initialize_widgets(md);
+        EventLoopIsActive=false;
+        block_till_exit_pushed=true;
+    } catch(...) {throw;}
+}
+/* Destructor  is not trivial here */
+SeismicPlot::~SeismicPlot()
+{
+    cerr << "Entering destructor"<<endl;
+    /* This may not be necessary, but probably prudent to avoid a deadlock */
+    if(EventLoopIsActive) this->ExitDisplay();
+    if(comp0!=NULL) delete comp0;
+    if(comp1!=NULL) delete comp1;
+    if(comp2!=NULL) delete comp2;
+    /* As I read it destroy the top level widget and destroy all the children. 
+       Hopefully this will not create a seg fault */
+    /* Using this creates problems.  Web research suggests this is probably 
+       because motif widgets are built with their own destructors.  With this
+       the program seg faults when this destructor is called. 
+    XtDestroyWidget(toplevel);
+    */
+}
+void SeismicPlot::plot(TimeSeriesEnsemble& d,bool block_for_event)
+{
+    try{
+	XtAppLock(AppContext);
+        /* Make an internal copy of d managed by the object to be 
+           consistent with 3C data.  We intentionally do not manage
+           the comp1 and comp2 pointers.   */
+        if(comp0!=NULL) delete comp0;
+        comp0=new TimeSeriesEnsemble(d);
+        XtVaSetValues(seisw[0],ExmNseiswEnsemble, (XtPointer) (comp0),
+            ExmNseiswMetadata,(XtPointer)(dynamic_cast<Metadata*>(this)), NULL);
+	XtAppUnlock(AppContext);
+        if(block_for_event) 
+            block_till_exit_pushed=true;
+        else
+            block_till_exit_pushed=false;
+        if(!EventLoopIsActive) 
+            this->launch_Xevent_thread_handler();
+    }
+    catch(...){throw;}
+}
+void SeismicPlot::refresh()
+{
+    try {
+	XtAppLock(AppContext);
+        int i;
+        for(i=0;i<3;++i)
+        {
+            if(seisw[i]!=NULL) XtVaSetValues(seisw[i],ExmNseiswMetadata, 
+                    (XtPointer)(dynamic_cast<Metadata*>(this)), NULL);
+        }
+        XtAppUnlock(AppContext);
+    }catch(...) {throw;}
+}
+/* TimeSeries and ThreeComponentSeismograms are plotted in window 1
+   using the same method as above.  Do this by simply creating a temporary
+   ensemble object and calling that method */
+void SeismicPlot::plot(TimeSeries& d,bool block_for_event)
+{
+    try {
+        TimeSeriesEnsemble e;
+        e.member.push_back(d);
+        this->plot(e,block_for_event);
+    } catch(...){throw;}
+}
+void SeismicPlot::plot(ThreeComponentSeismogram& d,bool block_for_event)
+{
+    try {
+        ThreeComponentEnsemble dtmp;
+        dtmp.member.push_back(d);
+        /*this assumes dtmp will be copied to 3 components "comp" in private 
+          are of this object.  This is a potential maintenance issue if that implementation
+          changes to be aware */
+        this->plot(dtmp,block_for_event);
+    }catch(...){throw;}
+}
+void SeismicPlot::plot(ThreeComponentEnsemble& d,bool block_for_event)
+{
+    try {
+        if(!ThreeComponentMode) throw SeisppError(string("SeismicPlot::plot method:  ")
+                + "Trying to plot 3c mode with ThreeComponentMode not set.  Fix pf");
+        cerr << "Entering 3c plot method"<<endl;
+        int k;
+	XtAppLock(AppContext);
+        for(k=0;k<3;++k)
+        {
+            auto_ptr<TimeSeriesEnsemble> c;
+            c=ExtractComponent(d,k);
+            /* This proved necessary to get around a mysterious behaviour I never figured out
+               if I tried to save the raw auto_ptr. I suspect it is related to the single owner
+               property of an auto_ptr which does not mesh well with passing data to the widget or
+               keeping it stored in this object.  We thus do the very inefficient thing and copy
+               the ensemble to a raw pointer.  */
+            TimeSeriesEnsemble *tstmp=new TimeSeriesEnsemble(*c);
+            switch (k)
+            {
+                case 1:
+                    if(comp1!=NULL) delete comp1;
+                    comp1=tstmp;
+                    XtVaSetValues(seisw[k],ExmNseiswEnsemble, (XtPointer) (comp1),
+                        ExmNseiswMetadata,(XtPointer)(dynamic_cast<Metadata*>(this)), NULL);
+                    break;
+                case 2:
+                    if(comp2!=NULL) delete comp2;
+                    comp2=tstmp;
+                    XtVaSetValues(seisw[k],ExmNseiswEnsemble, (XtPointer) (comp2),
+                        ExmNseiswMetadata,(XtPointer)(dynamic_cast<Metadata*>(this)), NULL);
+                    break;
+                case 0:
+                default:
+                    if(comp0!=NULL) delete comp0;
+                    comp0=tstmp;
+                    XtVaSetValues(seisw[k],ExmNseiswEnsemble, (XtPointer) (comp0),
+                        ExmNseiswMetadata,(XtPointer)(dynamic_cast<Metadata*>(this)), NULL);
+            }
+        }
+
+	XtAppUnlock(AppContext);
+        if(block_for_event) 
+            block_till_exit_pushed=true;
+        else
+            block_till_exit_pushed=false;
+        if(!EventLoopIsActive) 
+            this->launch_Xevent_thread_handler();
+    }catch(...){throw;}
+}
+void EventHandler(SeismicPlot *plot_handle)
+{
+    XtAppLock(plot_handle->AppContext);
+        do {
+            XEvent event;
+            XtAppNextEvent(plot_handle->AppContext,&event);
+            XtDispatchEvent(&event);
+        }while (plot_handle->WindowIsActive());
+    XtAppUnlock(plot_handle->AppContext);
+}
+void SeismicPlot::launch_Xevent_thread_handler()
+{
+    EventLoopIsActive=true;  // This may need a mutex
+    boost::thread Xevthrd(boost::bind(&EventHandler,this));
+    if(block_till_exit_pushed)
+    {
+        Xevthrd.join();
+        EventLoopIsActive=false;
+    }
+}
+/***** BEGIN TraceEditPlot code ************/
+
+/* This is a pair of labels that are posted on the edit menu 
+   displaying edit mode.  Edit is a toggle and this label will change
+   back and forth between these two codes */
+const string cutlabel("Switch to Single Trace Edit");
+const string stlabel("Switch to Cutoff Edit Mode");
+/* This callback does nothing.  It is purely a placeholder required
+   by the X interface to make btn2 active.  At least I don't see a way
+   to avoid it.  This is null because the widget knows about time series 
+   objects and the concept of the live boolean.  It has wired in it a
+   feature that toggles the live varibles when btn2 is pushed. */
+void ecb(Widget w, XtPointer client_data, XtPointer userdata)
+{
+    cerr << "ecb callback entered"<<endl;
+}
+void TraceEditPlot::edit_enable()
+{
+    /*Always initialize the widget in single trace mode which is 
+      what editon==1 means.  Set to 2 to enable cutoff edit function */
+    int editon(1);
+    for(int k=0;k<3;++k)
+    {
+        if(seisw[k]!=NULL)
+        {
+            XtVaSetValues(seisw[k],ExmNeditEnable,editon,NULL);
+            XtRemoveAllCallbacks(seisw[k],ExmNbtn2Callback);
+            // data pointer or this callback is intentionally NULL because
+            // callback does nothing
+            XtAddCallback(seisw[k],ExmNbtn2Callback,ecb,NULL);
+        }
+    }
+}
+void toggle_edit_callback(Widget w, XtPointer client_data, XtPointer call_data)
+{
+    TraceEditPlot *plot_handle=reinterpret_cast<TraceEditPlot *>(client_data);
+    plot_handle->toggle_edit_mode();
+}
+void TraceEditPlot::toggle_edit_mode()
+{
+    int k;
+    XmString str;
+    int kmax;
+    if(ThreeComponentMode)
+        kmax=3;
+    else
+        kmax=1;
+    for(k=0;k<kmax;++k)
+    {
+        XtRemoveAllCallbacks(this->seisw[k],ExmNbtn2Callback);
+        /* In each block below this is a toggle.  i.e. if one mode
+           switch to the other */
+	if(edit_mode==SINGLE_TRACE_EDIT_MODE)
+	{
+            edit_mode=CUTOFF_EDIT_MODE;
+            str = XmStringCreateLocalized(const_cast<char *>(cutlabel.c_str()));
+	}
+	else if(edit_mode==CUTOFF_EDIT_MODE)
+	{
+            edit_mode=SINGLE_TRACE_EDIT_MODE;
+            str = XmStringCreateLocalized(const_cast<char *>(stlabel.c_str()));
+	}
+	else
+	{
+	    /* Perhaps should throw an exception here, but instead we force
+	       default of single trace edit mode if edit_mode is mangled.
+	       This makes the result more robust but potentially mysterious
+	       if edit_mode were overwritten */
+            edit_mode=SINGLE_TRACE_EDIT_MODE;
+            str = XmStringCreateLocalized(const_cast<char *>(cutlabel.c_str()));
+	}
+        XtVaSetValues(this->seisw[k],ExmNeditEnable,edit_mode,NULL);
+        /* This is currently a do nothing callback.  In edit mode nothing
+           really needs to be reported with seisw as the plot is updated with
+           the killed traces zeroed and displayed red. */
+        XtAddCallback(this->seisw[k],ExmNbtn2Callback,ecb,NULL);
+        /* Set the label for the edit menu whether we toggle or not. */
+        XtVaSetValues(this->menu_edit,XmNlabelString,str,NULL);
+    }
+}
+
+void TraceEditPlot::build_edit_menu()
+{
+    /* Default forces single trace edit mode so use that label here. */
+    MenuItem edit_menu[]={
+        {const_cast<char *>(stlabel.c_str()),
+        &xmPushButtonGadgetClass,'c',
+        (char *)"<Key>C",(char *)"C",
+        toggle_edit_callback,
+        this,NULL,(MenuItem *)NULL},
+        {NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL}};
+    menu_edit=BuildMenu(menu_bar,XmMENU_PULLDOWN,
+            (char *)"Edit Mode",'E',
+            false,edit_menu);    
+    XtManageChild(menu_bar);
+}
+
+TraceEditPlot::TraceEditPlot() : SeismicPlot()
+{
+    /* Always initialize in single trace edit mode */
+    edit_mode=SINGLE_TRACE_EDIT_MODE;
+    this->edit_enable();
+    this->build_edit_menu();
+}
+TraceEditPlot::TraceEditPlot(Metadata& md) : SeismicPlot(md)
+{
+    /* Always initialize in single trace edit mode */
+    edit_mode=SINGLE_TRACE_EDIT_MODE;
+    this->edit_enable();
+    this->build_edit_menu();
+}
+set<int> TraceEditPlot::report_kills()
+{
+    set<int> result;
+    int i;
+    vector<TimeSeries>::iterator dptr;
+    if(comp0!=NULL)
+    {
+        for(dptr=comp0->member.begin(),i=0;
+          dptr!=comp0->member.end();++dptr,++i)
+            if(!dptr->live) result.insert(i);
+    }
+    if(comp1!=NULL)
+    {
+        for(dptr=comp1->member.begin(),i=0;
+          dptr!=comp1->member.end();++dptr,++i)
+            if(!dptr->live) result.insert(i);
+    }
+    if(comp2!=NULL)
+    {
+        for(dptr=comp2->member.begin(),i=0;
+          dptr!=comp2->member.end();++dptr,++i)
+            if(!dptr->live) result.insert(i);
+    }
+    //DEBUG
+    set<int>::iterator ikill;
+    cout << "TraceEditPlot returns this kill list:  ";
+    for(ikill=result.begin();ikill!=result.end();++ikill)
+    {
+        cout << *ikill <<", ";
+    }
+    return(result);
+}

--- a/lib/graphics/libseiswplot/SeismicPlot.h
+++ b/lib/graphics/libseiswplot/SeismicPlot.h
@@ -1,0 +1,178 @@
+#ifndef _SEISMICPLOT_H_
+#define _SEISMICPLOT_H_
+#include <pthread.h>
+#include "ensemble.h"
+#include "Seisw.h"
+#include "BasicSeisPlot.h"
+#include "SeismicPick.h"
+#include "Metadata.h"
+#include <Xm/MainW.h>
+#include <Xm/Form.h>
+#include <Xm/PushB.h>
+#include <Xm/PushBG.h>
+#include <Xm/PanedW.h>
+#include <Xm/RowColumn.h>
+#include <Xm/CascadeBG.h>
+#include <Xm/ToggleB.h>
+#include <Xm/ToggleBG.h>
+namespace SEISPP
+{
+using namespace std;
+using namespace SEISPP;
+/*! This defines a standardized interface to a plot for the SEISPP library.
+
+   This class is an attempt to abstract the basic plot functions required
+   to plot and work with seismic data.  It inherits an abstract base class
+   called BasicSeismicPlot which is a pure virtual base.  It also inherits
+   Metadata as a convenient way to change plot parameters.  An anomaly that
+   makes this a nonideal interface is that in the current implementation
+   this requires the refresh method to force the new parameters to take
+   effect.  It would be better if any parameter changes caused an immediate
+   redraw, but the current version based on Xt and the Seisw Motif widget
+   just can't do that.  
+
+   Because the implementation of this class is focused on the Seisw Motif
+   widget there is a very important limitation to note.  One must never
+   attempt to copy this object. The reason is that the X implemenation 
+   used here is simply not readily capable of handling multiple copies of
+   the same object in the same program.  There are several good reasons for
+   this but user should just realize the key rule - just don't ever try
+   to create copies of this plot handle.  A C++ compiler might just
+   allow you to do so because a default copy constructor and operator=
+   are often created even if you don't declare them.  
+
+   \author Gary L. Pavlis
+   */
+class SeismicPlot : public BasicSeisPlot, public Metadata
+{
+    public:
+        /*! Construct a plot handle using default parameters. 
+
+          Defaults for this object are stored in an Antelope a parameter file calld
+          SeismicPlot.pf stored in $ANTELOPE/data/pf.  This constructor uses pure
+          defaults for parameters. */
+        SeismicPlot();
+        /* Constructor using Metadata object to define plot parameters.
+
+           The plot geometry is defined by a large group of parameters passed to the
+           plotting widget through a Metadata object.  
+           \param md is the Metadata object that is assumed to contain the (fairly large) 
+                number of parameters needed to define the plot geometry. 
+            \exception Will throw a SeisppError object if plot parameters are missing.
+        */
+        SeismicPlot(Metadata& md);
+        /*! Destructor. 
+
+          Destructor for this beast is not trivial as we need to have the window system
+          clear the plot window and close it cleanly. */
+        ~SeismicPlot();
+        /*! Plot an ensemble of data.
+
+          This method plots an ensemble of scalar data in a single window frame. 
+
+          \param d is the ensemble to be plotted. 
+          \param blocking boolean to control whether or not the plot enters
+            an event loop (default true).  When true the caller will block
+            until the user exits through the user interface.  When false 
+            the plot is generated and the program continues immediately. 
+          */
+        void plot(TimeSeriesEnsemble& d,bool blocking=true);
+        /*! Plot a three component ensemble of data.
+
+          Three-component data could be plotted a variety of ways, but in this implmentation
+          this is plotted in 3 panes of the base window.
+
+          \param d is data to be plotted.
+          \param blocking boolean to control whether or not the plot enters
+            an event loop (default true).  When true the caller will block
+            until the user exits through the user interface.  When false 
+            the plot is generated and the program continues immediately. 
+          */
+        void plot(ThreeComponentEnsemble& d, bool blocking=true);
+        /*! Plot a single time series.
+
+          This is essentially a special case of a TimeSeriesEnsemble with one member and it is
+          treated that way.  i.e. you get a plot of the data with one trace in the window.
+          */
+        void plot(TimeSeries& d,bool blocking=true);
+        /*! Plot a single three-component seismogram.
+
+          A three component seismogram is plotted in the window 0 (the one labelled component 0) 
+          on a common time base.  The alternative would have been to display each component in a 
+          different window, which would not make sense for common use for this type of plot.  
+
+          \param d is the seismogram to be plotted.
+          \param blocking boolean to control whether or not the plot enters
+            an event loop (default true).  When true the caller will block
+            until the user exits through the user interface.  When false 
+            the plot is generated and the program continues immediately. 
+          */
+        void plot(ThreeComponentSeismogram& d,bool blocking=true);
+        /*! Make new plot parameters active.
+
+          This plot object inherits another a Metadata object.  You can thus use the 
+          get and put methods in Metadata to change parameters internally to this object's
+          internal data definitions.  The design of the Widget used to implement this 
+          class requires an explicit push of the entire Metadata object through an 
+          Xwindows call.  Rather than override the get and put methods I judged it 
+          preferable to use this model.  That is, if you want to change an plot
+          parameters use the Metadata put methods to change what you want.  When you
+          have put all the new parameters you want call this (refresh) method to 
+          have them new parameters pushed to the Widget.  
+          */
+        void refresh();
+        /*! Used internally to break the event loop.  
+
+          This really shouldn't be int he public interface, but I couldn't figure out
+          a way to get rid of it. */
+        void ExitDisplay(){
+            EventLoopIsActive=false; 
+        };
+        /*! Used internally by event loop thread to test for termination.
+
+          his really shouldn't be int he public interface, but I couldn't figure out
+                    a way to get rid of it. */
+        bool WindowIsActive(){
+            return EventLoopIsActive;
+        };
+        /*! X application context.
+
+          This plotting is based on X and I could not figure out a way to not put
+          this in the public interface and get threading to work right.  It really
+          doesn't belong here and a caller should never ever touch this. */
+        XtAppContext AppContext;
+        friend class TraceEditPlot;
+    protected:
+        /* When true calls to plot will block until until the exit button is
+           pushed.   When false a call to plot immediately returns. */
+        bool block_till_exit_pushed;
+        bool EventLoopIsActive;  // Set true when an event loop thread is running
+        /* These are used to be safe.  They may not be necessary, but 
+           because normally these are initialized from main this fakery
+           may be needed */
+        int argc;  
+        char *argv[1];
+        Widget toplevel,main_w;
+        Widget slrc,paned_win;
+        Widget continue_button;
+        Widget seisw[3];   // This is the set of seismic display widgets
+        //Widget seisw0,seisw1,seisw2;
+        //For now just one entry, add pick functions to menu bar later
+        Widget menu_bar,menu_file;
+        /* Private method that launches event handler thread */
+        void launch_Xevent_thread_handler();
+        /* We will need this to implement kills on a 3c ensemble.  Intentionally 
+           commented out initially as this is a nasty add on that may never happen. */
+        //ThreeComponentEnsemble *parent3c;
+        /* These are temporaries needed to cache data being plotted.
+           Without this we will get a seg fault when the ensemble goes out of scope
+           because the widget accepts a raw pointer */
+        TimeSeriesEnsemble *comp0,*comp1,*comp2;
+        /*! Private method initializes widgets in a regular way.
+          
+          This is mainly here to provide common code for unparameterized
+          constructor and the one using a Metadata.*/
+        void initialize_widgets(Metadata& md);
+};
+}
+#endif

--- a/lib/graphics/libseiswplot/SeismicPlot.h
+++ b/lib/graphics/libseiswplot/SeismicPlot.h
@@ -110,7 +110,7 @@ class SeismicPlot : public BasicSeisPlot, public Metadata
         void plot(ThreeComponentSeismogram& d,bool blocking=true);
         /*! Make new plot parameters active.
 
-          This plot object inherits another a Metadata object.  You can thus use the 
+          This plot object inherits a Metadata object.  You can thus use the 
           get and put methods in Metadata to change parameters internally to this object's
           internal data definitions.  The design of the Widget used to implement this 
           class requires an explicit push of the entire Metadata object through an 

--- a/lib/graphics/libseiswplot/SeismicPlot.pf
+++ b/lib/graphics/libseiswplot/SeismicPlot.pf
@@ -1,0 +1,53 @@
+# these are plot parameters 
+
+
+    SUVariableArea_grey_value	1
+    VariableArea	true
+    WiggleTrace	true
+    blabel	Data Window
+    blabel2	Data Window
+    clip_data	true
+    clip_percent	99.5
+    clip_wiggle_traces	false
+    d1num	0.0
+    d2num	0.0
+    default_curve_color	black
+    f1num	0.0
+    f2num	0.0
+    first_trace_offset	0.0
+    grid1	1
+    grid2	1
+    gridcolor	blue
+    hbox	5000
+    interpolate	true
+    label1	time
+    label2	index
+    labelcolor	blue
+    labelfont	Rom14
+    labelsize	18.0
+    n1tic	5
+    n2tic	1
+    plot_file_name	SeismicPlot.ps
+    style	normal
+    time_axis_grid_type	solid
+    time_scaling	auto
+    title	Data Aligned by Arrival Time
+    titlecolor	red
+    titlefont	Rom22
+    titlesize	36.0
+    trace_axis_attribute	assoc.delta
+    trace_axis_grid_type	none
+    trace_axis_scaling	auto
+    trace_spacing	1.0
+    trim_gap_edges	true
+    use_variable_trace_spacing	false
+    verbose	true
+    wbox	1000
+    windowtitle	SeismicPlot
+    x1beg	0.0
+    x1end	120.0
+    x2beg	0.0
+    x2end	24.0
+    xbox	50
+    xcur	1.0
+    ybox	50

--- a/lib/graphics/libseiswplot/TimeWindowPicker.cc
+++ b/lib/graphics/libseiswplot/TimeWindowPicker.cc
@@ -1,0 +1,81 @@
+#include "TimeWindowPicker.h"
+using namespace SEISPP;
+namespace SEISPP {
+
+void pick_tw_callback(Widget w, XtPointer client_data, XtPointer userdata)
+{
+    cerr << "Entering pick_tw_callback"<<endl;
+    TimeWindowPicker *picker_handle=reinterpret_cast<TimeWindowPicker*>
+        (client_data);
+    TimeWindow twinpicked;
+    SeismicPick *spick;
+    XtVaGetValues(w,ExmNseiswPick,&spick,NULL);
+    twinpicked=spick->get_window();
+    // Silently drop a pick if not properly tagged.  
+    if(spick->type == WINDOW) 
+        picker_handle->setpick(twinpicked);
+
+    cerr << "Leaving pick_tw_callback"<<endl;
+}
+void TimeWindowPicker::setpick(TimeWindow twinpicked)
+{
+    cerr << "Entering setpick"<<endl;
+    picked_window=twinpicked;
+    pick_completed=true;
+    // freeze this for now
+    markers.beam_color=string("red");
+    markers.beam_tw=twinpicked;
+    int k,kmax;
+    if(ThreeComponentMode)
+        kmax=3;
+    else
+        kmax=1;
+    for(k=0;k<kmax;++k)
+        XtVaSetValues(this->seisw[k],ExmNdisplayMarkers,&markers,NULL);
+    cerr << "Leaving setpick"<<endl;
+}
+void TimeWindowPicker::enable_picking()
+{
+    cerr << "Entering enable_picking"  <<endl;
+    int k,kmax;
+    if(ThreeComponentMode)
+        kmax=3;
+    else
+        kmax=1;
+    for(k=0;k<kmax;++k)
+    {
+        cerr << "Adding callbacks for seisw widget number "<<k<<endl;
+        XtRemoveAllCallbacks(seisw[k],ExmNbtn3Callback);
+        XtAddCallback(seisw[k],ExmNbtn3Callback,pick_tw_callback,(XtPointer)this);
+    }
+    cerr << "Exiting enable_picking"  <<endl;
+}
+TimeWindowPicker::TimeWindowPicker() : SeismicPlot(), picked_window()
+{
+    this->enable_picking();
+    pick_completed=false;
+}
+TimeWindowPicker::TimeWindowPicker(Metadata& md) : SeismicPlot(md) ,
+    picked_window()
+{
+    cerr << "Entering TimeWindowPicker(Metadata) constructor"<<endl;
+    this->enable_picking();
+    pick_completed=false;
+    cerr << "Exiting TimeWindowPicker(Metadata) constructor"<<endl;
+}
+TimeWindow TimeWindowPicker::get()
+{
+    if(!pick_completed)throw SeisppError(
+       string("TimeWindowPicker get method:  ")
+      +string("no time window was picked.\n")
+      +string("Error handler should allow you to try again"));
+    pick_completed=false;
+    return picked_window;
+}
+void TimeWindowPicker::repick()
+{
+    // This is a protected method is SeismicPlot so this method is 
+    // little more than an alias for that method 
+    this->launch_Xevent_thread_handler();
+}
+} // End SEISPP namespace encapsulation

--- a/lib/graphics/libseiswplot/TimeWindowPicker.h
+++ b/lib/graphics/libseiswplot/TimeWindowPicker.h
@@ -1,0 +1,70 @@
+#ifndef _TIME_WINDOW_PICKER_H_
+#define _TIME_WINDOW_PICKER_H__
+#include "TimeWindow.h"
+#include "SeismicPlot.h"
+#include "display_marker.h"
+namespace SEISPP
+{
+using namespace std;
+using namespace SEISPP;
+/*! Plots seismic data to for picking a time window.
+
+This object builds a seismic display plot identical to it's parent
+called SeismicPlot.  The key difference is that it enables the 
+the time window picking function feature of the seisw widget.
+Normal usage is expected to be to create the window with one of
+the contructors, load data with the plot methods of SeisicPlot, 
+pick a time window with MB3, exit the graphic loop (x key stroke
+in SeismicPlot window), and then retrieve the window with the 
+get method.  The get method has a simple sanity check to make 
+sure a pick has been made.  See get method description below.
+Note repeated picks before exiting the plot event loop will 
+overwrite the previous.  Thus be aware the last pick made is 
+the one that will be returned by the get method.
+
+Because this plot handle is a child of SeismicPlot the warnings
+described for the SeismicPlot object about copies applies equally 
+here.  See documentation for SeismicPlot for a longer explanation.
+
+\author Gary L. Pavlis
+*/
+class TimeWindowPicker : public SeismicPlot
+{
+public:
+    TimeWindowPicker();
+    TimeWindowPicker(Metadata& md);
+    /*! Fetch the picked time window.
+
+      This method is used to get the result of picking a time window.
+      This is a less than trivial thing because we have to handle the
+      highly likely scenario that the user failed to make a valid time
+      pick.  The get method is effectively a one shot.  You can retrieve
+      a time pick only once without an error.  If a repick is required call
+      the rearm method.  
+
+      Similarly if this method is called and no time window has been picked 
+      this method will throw an exception.  Most programs should handle this
+      exception cleanly without an exit and immediately call the repick 
+      method.  
+
+      \exception SeisppError is thrown if this method is called with a 
+      valid pick having been made from the data. 
+
+      */
+    TimeWindow get();
+    /*! Rearm the picking function to try again.
+
+    The plot window is armed on construction or after loading a new set
+    of data, but has to be disarmed to call the get method.  This method
+    is normally called to "try again". 
+    */
+    void repick();
+    void setpick(TimeWindow tw);
+private:
+    void enable_picking();
+    TimeWindow picked_window;
+    bool pick_completed;
+    DisplayMarkerDataRec markers;
+};
+} // End SEISPP namespace encapsulation
+#endif

--- a/lib/graphics/libseiswplot/TimeWindowPicker.h
+++ b/lib/graphics/libseiswplot/TimeWindowPicker.h
@@ -31,7 +31,23 @@ here.  See documentation for SeismicPlot for a longer explanation.
 class TimeWindowPicker : public SeismicPlot
 {
 public:
+    /*! Default constructor.
+
+      The default constructor does little more than call the 
+      SeismicPlot default constructor.  That looks for a default
+      pf definition in a standard place.  
+      */
     TimeWindowPicker();
+    /*! Call with setup parameters.
+
+      This constructor explicitly passes plot parameters through
+      the Metadata object.   The parameters are not different from
+      the base class SeismicPlot.   
+
+      \param md is the Metadata object with plot parameters.
+      \exception SeisppError object thrown if parameters are missing 
+      or something goes haywired in launching the window. 
+      */
     TimeWindowPicker(Metadata& md);
     /*! Fetch the picked time window.
 
@@ -59,6 +75,16 @@ public:
     is normally called to "try again". 
     */
     void repick();
+    /* \brief Initialize window markers.
+
+       This method is heavily used internally to set the position of the
+       time window markers.  For the public interface it can be a useful
+       way to set a default initial window.   e.g. it is commonly useful
+       to start with a default time window that can be just accepted in
+       most cases making the gui more efficient to use.
+
+       \param tw is the window to be posted on the plot.
+       */
     void setpick(TimeWindow tw);
 private:
     void enable_picking();

--- a/lib/graphics/libseiswplot/TraceEditPlot.h
+++ b/lib/graphics/libseiswplot/TraceEditPlot.h
@@ -36,8 +36,25 @@ here.  See documentation for SeismicPlot for a longer explanation.
 class TraceEditPlot : public SeismicPlot
 {
 public:
+    /*! Default constructor. 
+
+      Does little more than call the default constructor for its parent
+      SeismicPlot.*/
     TraceEditPlot();
+    /*! Construct with explicit plot parameters.
+
+      This constructor explicitly passes plot parameters through a
+      metadata object.  Little more than a call to base class
+      SeismicPlot constructor. */
     TraceEditPlot(Metadata& md);
+    /*! \brief Return list of kills.
+
+      Edits are explicitly killed by the widget and made into flat
+      lines on the plot.  They are also marked dead.  However, it often
+      necessary to get the list of which seismograms were marked bad.
+      This does this by returning these as an STL set of integers 
+      defining ensemble members marked bad.   The user can use these
+      to either edit the ensemble or make sure dead is dead.  */
     set<int> report_kills();
     /*! Toggle between single trace and cutoff mode editing. 
      
@@ -56,6 +73,19 @@ private:
        set 2 for cutoff mode */
     int edit_mode;
 };
+/*! \brief Companion procedure for report_kills method of TraceEditPlot object.
+
+  Use this procedure to kill ensemble members defined by the stl set 
+  container returned by the report_kills method.
+
+  \param ensemble is that was passed to TraceEditPlot and interactively edited.
+  \param kills is the output of the report_kills method of TraceEditPlot.
+
+  \exception SeisppError will be thrown if the kill list has an invalid integer.
+        This should not normally happen, but would likely indicate a coding 
+        error.
+
+  */
 template <class T> void killmembers(T& ensemble,set<int> kills)
 {
     if(kills.empty()) return;

--- a/lib/graphics/libseiswplot/TraceEditPlot.h
+++ b/lib/graphics/libseiswplot/TraceEditPlot.h
@@ -1,0 +1,75 @@
+#ifndef _TRACEEDITPLOT_H_
+#define _TRACEEDITPLOT_H__
+#include "SeismicPlot.h"
+#define SINGLE_TRACE_EDIT_MODE 1
+#define CUTOFF_EDIT_MODE 2
+namespace SEISPP
+{
+using namespace std;
+using namespace SEISPP;
+/*! Make a plot with trace edit functions enabled.
+
+This object builds a seismic display plot identical to it's parent
+called SeismicPlot.  The key difference is that in enables edit functions
+in the seisw Widget.   The edit functions are of two form:  (1) single
+trace kill and (2) a cutoff method kill.  The first is implemented by 
+pointing at a trace and clicking MB2.  The second is implemented with
+shift-MB2.  The cutoff editing is similar to that used in dbxcor where
+the set of trace below the water mark picked will be killed.  Cutoff makes
+sense only if the data are presorted by some metric that defines a level
+of badness.  The seisw editor implements kills by setting the live boolean
+of the family of time series objects used in my library. Because the 
+SeismicPlot object from which this is derives caches a copy of an original
+data set the primary method of this object is the report_edit function.
+It returns a list of integer index values to the parent ensemble. The caller
+must then use this list to implement the kills.  Since what that means is
+application dependent it was a design decision to not provide methods
+that use this info.  A template is provided below, however, to implement
+this in the way I intend with the live variable of time series type objects.
+
+Because this plot handle is a child of SeismicPlot the warnings
+described for the SeismicPlot object about copies applies equally 
+here.  See documentation for SeismicPlot for a longer explanation.
+
+\author Gary L. Pavlis
+*/
+class TraceEditPlot : public SeismicPlot
+{
+public:
+    TraceEditPlot();
+    TraceEditPlot(Metadata& md);
+    set<int> report_kills();
+    /*! Toggle between single trace and cutoff mode editing. 
+     
+     The plot produced by this object always is initialized
+     in single trace edit mode.  Calling this method changes
+     the edit mode to cutoff where clicking on mb2 kills or 
+     restores all data below a picked trace.*/
+    void toggle_edit_mode();
+private:
+    Widget menu_edit;
+    /* These two private methods are used to allow common code for
+       constructors. */
+    void edit_enable();
+    void build_edit_menu();
+    /* This is used by Seisw widget.  1 for single trace edit mode
+       set 2 for cutoff mode */
+    int edit_mode;
+};
+template <class T> void killmembers(T& ensemble,set<int> kills)
+{
+    if(kills.empty()) return;
+    int nm=ensemble.member.size();
+    set<int>::iterator kptr;
+    for(kptr=kills.begin();kptr!=kills.end();++kptr)
+    {
+        int ik=(*kptr);
+        if(ik>=nm) 
+            throw SeisppError(string("killmembers:  ")
+                + "string index is larger than ensemble size\n");
+        else
+            ensemble.member[ik].live=false;
+    }
+}
+} // End SEISPP namespace encapsulation
+#endif

--- a/lib/graphics/libseiswplot/makefile
+++ b/lib/graphics/libseiswplot/makefile
@@ -1,0 +1,10 @@
+
+all clean Include install installMAN pf relink tags uninstall test :: FORCED
+	@-if localmake_config xmotif boost; then \
+	    $(MAKE) -f Makefile2 $@ ; \
+	fi
+
+clean uninstall :: FORCED
+	$(MAKE) -f Makefile2 $@
+
+FORCED:

--- a/lib/graphics/seisw/Makefile2
+++ b/lib/graphics/seisw/Makefile2
@@ -13,6 +13,7 @@ include $(ANTELOPEMAKE)
 include $(ANTELOPEMAKELOCAL)
 
 CXXFLAGS += -I$(XMOTIFINCLUDE)
+CXXFLAGS += -I$(BOOSTINCLUDE)
 #Remove this comment to enable verbose stuff from seisw widget
 #CXXFLAGS += -DDEBUG_WIDGET
 

--- a/lib/seismic/libseispp/SimpleWavelets.h
+++ b/lib/seismic/libseispp/SimpleWavelets.h
@@ -31,11 +31,11 @@ TimeSeries gaussian_wavelet(int n, double dt, double sigma,
 
   \param n length of output time series object to hold wavelet
   \param dt sample interval of output time series.  Length with be
-     (n-1)*dt with the 0 time at n/2.  
-  \param nu ricker wavelet width parameter.  Note nu=1/f_m where f_m is
+     (n-1)*dt with the 0 time at n/2.   
+  \param nu ricker wavelet width parameter that is commonly called
      the peak frequency.   Note time between negative sidebands is 
-     sqrt(6)*nu/pi and zero crossing measure of peak width is 
-     sqrt(2)*nu/pi.
+     sqrt(6)/(nu*pi) and zero crossing measure of peak width is 
+     sqrt(2)/(nu*pi).
   \param normalize is the normalization method to use.  Only PEAK
     or NONE are accepted.  If passed AREA this will throw an exception. 
  

--- a/lib/seismic/libseispp/ensemble.cc
+++ b/lib/seismic/libseispp/ensemble.cc
@@ -63,22 +63,6 @@ TimeSeriesEnsemble::TimeSeriesEnsemble(DatabaseHandle& rdb,
 			dbhv.db.record<ensemble_bundle.end_record;
 			++i,++dbhv.db.record)
 		{
-			try {
-				d = new TimeSeries(*rdbhv,
-					station_mdl,am);
-			} catch (SeisppError& dberr)
-			{
-				cerr << "Problem with member "
-					<< i 
-					<< " in ensemble construction" << endl;
-				dberr.log_error();
-				cerr << "Data for this member skipped" << endl;
-				continue;
-			}
-			//other errors require aborting
-			catch (...){throw;};
-			member.push_back(*d);
-			delete d;
 			// copy global metadata only for the first 
 			// row in this view
 			if(i==0)
@@ -96,12 +80,30 @@ TimeSeriesEnsemble::TimeSeriesEnsemble(DatabaseHandle& rdb,
 				{
 					dbhvsta=dbhv;
 				}
+                                try{
 				Metadata ens_md(dynamic_cast<DatabaseHandle&>(dbhvsta),
 					ensemble_mdl,am);
 				copy_selected_metadata(ens_md,
 					dynamic_cast<Metadata&>(*this),
 					ensemble_mdl);
+                                }catch(...){throw;};
 			}
+			try {
+				d = new TimeSeries(*rdbhv,
+					station_mdl,am);
+			} catch (SeisppError& dberr)
+			{
+				cerr << "Problem with member "
+					<< i 
+					<< " in ensemble construction" << endl;
+				dberr.log_error();
+				cerr << "Data for this member skipped" << endl;
+				continue;
+			}
+			//other errors require aborting
+			catch (...){throw;};
+			member.push_back(*d);
+			delete d;
 		}
                 if(SEISPP_verbose) cout <<this_function_base_message
                     << ":  Number of seismograms loaded="
@@ -681,26 +683,11 @@ ThreeComponentEnsemble::ThreeComponentEnsemble(DatabaseHandle& rdb,
 			dbhv.db.record<ensemble_bundle.end_record;
 			++i,++dbhv.db.record)
 		{
-			try {
-				data3c = new ThreeComponentSeismogram(*rdbhv,
-					station_mdl,am);
-			} catch (SeisppError& dberr)
-			{
-				cerr << "Problem with member "
-					<< i 
-					<< " in ensemble construction" << endl;
-				dberr.log_error();
-				cerr << "Data for this member skipped" << endl;
-				continue;
-			}
-			//With any other error we cannot continue
-			catch(...) {throw;};
-			member.push_back(*data3c);
-			delete data3c;
 			// copy global metadata only for the first 
 			// row in this view
 			if(i==0)
 			{
+                            try{
 				DatascopeHandle dbhvsta;
 				if(dbhv.is_bundle)
 				{
@@ -719,7 +706,24 @@ ThreeComponentEnsemble::ThreeComponentEnsemble(DatabaseHandle& rdb,
 				copy_selected_metadata(ens_md,
 					dynamic_cast<Metadata&>(*this),
 					ensemble_mdl);
+                            }catch(...){throw;};
 			}
+			try {
+				data3c = new ThreeComponentSeismogram(*rdbhv,
+					station_mdl,am);
+			} catch (SeisppError& dberr)
+			{
+				cerr << "Problem with member "
+					<< i 
+					<< " in ensemble construction" << endl;
+				dberr.log_error();
+				cerr << "Data for this member skipped" << endl;
+				continue;
+			}
+			//With any other error we cannot continue
+			catch(...) {throw;};
+			member.push_back(*data3c);
+			delete data3c;
 		}
                 if(SEISPP_verbose) cout <<this_function_base_message
                     << ":  Number of seismograms loaded="


### PR DESCRIPTION
I decided it was time to put this plot library into the repository.   Contains a polymorphic set of C++ objects built on the seisw widget used by dbxcor.   The objective was to abstract two common gui needs for handling data:  trace editing and time window picking.   The library is intimately linked to the seisw widget, but is a vastly simplified interface.   The core interface provides a useful standard for standard seismic plot library.