### PR TITLE
Fix inconsistency of environment variable name with documentation

### DIFF
--- a/lib/tt/libtt1dcvl/tt1dcvl.c
+++ b/lib/tt/libtt1dcvl/tt1dcvl.c
@@ -45,7 +45,6 @@ name from the environment using a default if the variable is
 not set.  
 */
 static Dbptr modeldb;
-#define VMODEL_DBNAME_CUSTOM "VELOCITY_MODEL_DATABASE"
 #define VMODEL_DBNAME_DEFAULT "vmodel"
 
 int _tt1dcvl_has_run = 0;
@@ -65,7 +64,7 @@ void tt1dcvl_init()
 	char *dbpath;
 	char *dbname;
 
-	dbname=getenv(VMODEL_DBNAME_CUSTOM);
+	dbname=getenv("VELOCITY_MODEL_DATABASE");
 	if(dbname==NULL)
 		dbpath = datapath (NULL,"tables/genloc/db",VMODEL_DBNAME_DEFAULT,NULL);
 	else


### PR DESCRIPTION
This was uncovered when trying to figure out a problem with dbgenloc reported by John Nabelek.  This was not his problem, but is a minor bug that needs to be squashed,