### PR TITLE
Important SEISPP bug fix

### DIFF
--- a/bin/db/autoxcor/Makefile
+++ b/bin/db/autoxcor/Makefile
@@ -1,0 +1,11 @@
+
+all Include install installMAN pf relink tags test :: FORCED
+	@-if localmake_config boost ; then \
+	    $(MAKE) -f Makefile2 $@ ; \
+	fi
+
+clean uninstall :: FORCED
+	$(MAKE) -f Makefile2 $@
+
+FORCED:
+

--- a/bin/db/autoxcor/Makefile2
+++ b/bin/db/autoxcor/Makefile2
@@ -1,0 +1,18 @@
+BIN=autoxcor
+PF=autoxcor.pf
+
+ldlibs=-L$(XMOTIFLIB) -lXm -lXt \
+	-lgclgrid -lseispp -lperf -lseispp $(TRLIBS) $(DBLIBS)  \
+       $(F77LIBS) $(X11LIBS) -L$(BOOSTLIB) -lboost_thread -lboost_system
+
+SUBDIR=/contrib
+ANTELOPEMAKELOCAL = $(ANTELOPE)/contrib/include/antelopemake.local
+include $(ANTELOPEMAKE)  	
+include $(ANTELOPEMAKELOCAL)
+
+CXXFLAGS += -I$(XMOTIFINCLUDE)
+CXXFLAGS += -I$(BOOSTINCLUDE)
+
+OBJS= autoxcor.o 
+$(BIN) : $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJS) $(LDFLAGS) $(LDLIBS)

--- a/bin/db/autoxcor/autoxcor.cc
+++ b/bin/db/autoxcor/autoxcor.cc
@@ -1,0 +1,857 @@
+#include <vector>
+#include <list>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <string>
+#include <cstdlib>
+#include <time.h>
+#include <cmath>
+#include <complex>
+
+#include "SeisppKeywords.h"
+#include "TimeSeries.h"
+#include "ThreeComponentSeismogram.h"
+#include "ensemble.h"
+#include "Metadata.h"
+#include "Hypocenter.h"
+#include "dbpp.h"
+#include "filter++.h"
+#include "resample.h"
+#include "seispp.h"
+#include "stack.h"
+#include "SignalToNoise.h"
+#include "MultichannelCorrelator.h"
+#include "PfStyleMetadata.h"
+
+/*
+This the program that aligns all the traces in a event gather and computes
+the stack of all vertical components. Input and output
+are all based on antelope database. 
+All parameters are defined in the autoxcor.pf.
+*/
+
+using namespace std;
+using namespace SEISPP;
+
+bool SEISPP::SEISPP_verbose(true);
+/*! \brief Generic algorithm to load arrival times from a database.
+
+In passive array processing a very common need is to extract time windows
+around marked phase pick or a theoretical arrival time.  For measured
+arrival times the css database has an awkward link to waveforms that 
+causes problems when dealing with continuous data.  This is one element of
+a set of functions aimed at dealing with this problem.  
+
+This particular procedure aims to take an input ensemble of data and 
+find matches for arrival times in an external database.  For each member
+of the ensemble with a matching arrival it posts the arrival time to the
+generalized header (Metadata) of the parent object.  To avoid testing 
+for valid arrivals in the ensemble after this procedure is run a index
+of data with valid arrivals is returned as an stl list container of ints.
+
+\param dat is the input ensemble passed as a reference to the vector 
+	container of data objects.  The type of the objects in the container
+	is generic except class T MUST be an object that inherits Metadata.
+	At time of this writing T could be TimeSeries, ThreeComponentSeismogram,
+	or ComplexTimeSeries. 
+\param dbh match handle to a Datascope database containing arrival. 
+	Normally this should reference the standard catalog view.  That
+	is:  event->origin->assoc->arrival subsetted to orid==prefor.
+	The algorithm actually only cares that a find using the Metadata
+	area of the vector data components will provide a unique match
+	into the table the handle references (normally arrival).  This 
+	tacitly assumes the handle has been properly constructed and the
+	proper attributes have been loaded with the data to provide a unique
+	match into arrival.  With css this REQUIRES that each component of
+	dat MUST have had evid and/or orid posted before calling this function.  There
+	is no other unambiguous way to match waveforms in this context to
+	a unique arrival. 
+\param keyword is the attribute name used to posted the arrival time data.
+
+\return list of members of input vector with valid arrival times posted.
+	The contents of the list can be traversed and used with operator[]
+	to extract valid data from the ensemble.  
+*/
+list<long> LoadArrivalTimes(vector<ThreeComponentSeismogram>& dat,
+                DatascopeMatchHandle& dbh,
+		    const string keyword)
+{
+        std::vector<ThreeComponentSeismogram>::iterator d;
+	long i;
+	list<long> data_with_arrivals;
+	const string base_error("Warning (LoadArrivalTimes): ");
+	for(d=dat.begin(),i=0;d!=dat.end();++d,++i)
+	{
+		double atime;  //  arrival time.  
+		long aid;
+		if(d->live)
+		{
+		// First see if there is an arrival for this
+		// station.  If not, skip it. 
+			list<long> records
+				=dbh.find(dynamic_cast<Metadata&>(*d),false);
+			// if no arrival silently skip data for this station
+			if(records.size()<=0) continue;
+			if(records.size()>1)
+			{
+				string sta=d->get_string("sta");
+				cerr << base_error 
+					<< "found "
+					<< records.size()
+					<< " arrivals for station "
+					<< sta <<endl
+					<< "Using first found "
+					<< "in database view"<<endl;
+			}
+			Dbptr db=dbh.db;
+			// tricky usage here.  begin() returns
+			// an iterator so the * operator gets the
+			// value = record number of the match
+			db.record=*(records.begin());
+			char csta[10];
+			if(dbgetv(db,0,"arrival.time",&atime,"sta",csta,0)
+				== dbINVALID) 
+			{
+				string sta=d->get_string("sta");
+				cerr << base_error
+					<< "dbgetv failed"
+					<< " in attempt to obtain"
+					<< " arrival time for station"
+					<< sta << endl
+					<< "Data from this station"
+					<< " will be dropped"<<endl;	
+			}
+			dbgetv(db,0,"arrival.arid",&aid,"sta",csta,0);
+			d->put(keyword,atime);
+			d->put(keyword+".arid",aid);
+			data_with_arrivals.push_back(i);
+		}
+	}
+	return(data_with_arrivals);
+} 
+void PostEvid(ThreeComponentEnsemble *d,int evid)
+{
+	vector<ThreeComponentSeismogram>::iterator dptr;
+	for(dptr=d->member.begin();dptr!=d->member.end();++dptr)
+		dptr->put("evid",evid);
+}
+/*! \brief Builds a standard catalog view from a CSS3.0 database.
+
+Much passive array processing is built around the css3.0 schema.
+The css3.0 schema has a standard view that defines the definitive
+catalog for a network.  This is formed by the join of:
+	event->origin->assoc->arrival
+and is usually (as here) subsetted to only keep rows with
+orid equal to the "preferred origin" (prefor).  This procedure
+builds a handle to this database view.
+
+\param dbh is a handle to the parent Datascope database 
+	from which the view is to be constructed.  It need
+	only reference the correct database. 
+\return new handle that refers to the "standard" catalog view
+	described above.
+*/
+DatascopeHandle StandardCatalogView(DatascopeHandle& dbh)
+{
+	DatascopeHandle result(dbh);
+	dbh.lookup("event");
+	dbh.natural_join("origin");
+	string ss_to_prefor("orid==prefor");
+	dbh.subset(ss_to_prefor);
+	dbh.natural_join("assoc");
+	dbh.natural_join("arrival");
+	return(dbh);
+}
+/*! \brief Multiple stage TimeInvariantFilter operator.
+
+Sometimes it is necessary to apply a series of stages of
+filtering to equalize different data sets or just to 
+simply the process of defining a multiple filter chain.
+This object simplifies that process by allowing the definition
+of a chain of filters and a set of supplied methods to apply
+these filters to data.
+*/
+class MultiStageFilter
+{
+public:
+	/*! \brief Default constructors.  
+
+	Loads a null filter definition.  That is the default is
+	a do nothing operator. */
+	MultiStageFilter();
+	/*! \brief Construct the filter definitions from a string.
+
+	This is currently the prime constructor.  A string is parsed
+	into tokens that describe a series of filters that will be
+	chained together.  The strings that define each individual
+	filter type are parsed into blocks determined by the separator
+	argument.  The parsed strings are currently used to construct
+	a set of TimeInvariantFilter processing objects.
+	An example helps explain how this would be used.  If we
+	passed "DEMEAN; BW 0.5 5 2 5" and define ";" as the separator
+	this would yield a two stage filter:  demean followed by a 
+	0.5 to 2 Hz bandpass filter.
+
+	\param filterlist contains the set of filter recipes to use.
+	\param separator is the string used as a separator between
+		the recipes for each filter description.
+	*/
+	MultiStageFilter(string filterlist,string separator);
+	template <class T> void  apply(T& d);
+private:
+	list<TimeInvariantFilter> stages;
+};
+MultiStageFilter::MultiStageFilter()
+{
+	TimeInvariantFilter f(string("none"));
+	stages.push_back(f);
+}
+MultiStageFilter::MultiStageFilter(string filterlist,string separator)
+{
+    try {
+	const string white(" \t\n");
+	int current=0,end_current;
+	string stmp;
+	string filterparam;
+	// Strip any leading white space
+	stmp=filterlist;
+	if((current=stmp.find_first_not_of(white,0)) != 0)
+	{
+		stmp.erase(0,current);
+		current=0;
+	}
+	int endstmp=stmp.size();
+	do {
+		end_current=stmp.find_first_of(separator,current);
+		if(end_current<0)
+		{
+			filterparam.assign(stmp,current,endstmp);
+			stages.push_back(TimeInvariantFilter(filterparam));
+			break;
+		}			
+		filterparam.assign(stmp,current,end_current-current);
+		stages.push_back(TimeInvariantFilter(filterparam));
+		current=stmp.find_first_not_of(separator,end_current);
+		current=stmp.find_first_not_of(white,current);
+	}
+	while(current<endstmp && current>=0);
+    } catch (...) {throw;};
+}
+		
+	
+	
+/* For now this only works on ensembles.  */
+template <class T> void MultiStageFilter::apply(T& d)
+{
+    try {
+	list<TimeInvariantFilter>::iterator filt;
+	for(filt=stages.begin();filt!=stages.end();++filt)
+		FilterEnsemble(d,*filt);
+	/* Note this template could be made to work with TimeSeries
+	 or ThreeComponentSeismogram components individually if 
+	we used a typeid check on T and then used this line
+	for that type of beast:  filt->apply(d);
+	*/
+    } catch (...) {throw;};
+}
+void ApplyFST(ThreeComponentEnsemble& e,Hypocenter& hypo)
+{
+	double vp0(6.0),vs0(3.5);
+	for(int i=0;i<e.member.size();++i)
+	{
+		double lat,lon,elev;
+		lat=e.member[i].get_double("lat");
+		lon=e.member[i].get_double("lon");
+		elev=e.member[i].get_double("elev");
+		SlownessVector u=hypo.pslow(lat,lon,elev);
+		e.member[i].free_surface_transformation(u,vp0,vs0);
+	}
+}
+void ApplyFST(ThreeComponentSeismogram& e,Hypocenter& hypo)
+{
+	double vp0(6.0),vs0(3.5);
+	double lat,lon,elev;
+	lat=e.get_double("lat");
+	lon=e.get_double("lon");
+	elev=e.get_double("elev");
+	SlownessVector u=hypo.pslow(lat,lon,elev);
+	e.free_surface_transformation(u,vp0,vs0);
+	
+}
+
+template <class T> T VectorMedian(vector<T> v)
+{
+	sort(v.begin(),v.end());
+	int size=v.size();
+	return (size % 2 ? v[size/2] : (v[size/2-1]+v[size/2])/2);
+}
+template <class T> T VectorMean(vector<T> v)
+{
+	T sum=0.0;
+	for(int i=0;i<v.size();i++)
+		sum+=v[i];
+	return (sum/v.size());
+}
+
+TimeWindow SemblanceSearch(TimeSeriesEnsemble &t, Metadata &md)
+{
+	/*wind=1000;
+	da=x3(:,:);
+	sembl=zeros(floor(size(da,1)/wind)*2-1,1);
+	k=0;
+	for i=wind/2:wind/2:floor(size(da,1)/wind)*wind-wind/2
+	    k=k+1;
+	    stack=median(da(i-(wind/2-1):i+wind/2,:),2)*size(da,2);
+	    danorm=zeros(size(da,2),1);
+	    for j=1:size(da,2)
+		danorm(j)=norm(da(i-(wind/2-1):i+wind/2,j));
+	    end
+	    sembl(k)=norm(stack)/(median(danorm)*size(da,2));
+	end*/
+	double dt=md.get_double("target_sample_interval");
+	int wind=(int)floor(md.get_double("semblance_window")/dt);
+	double sembllimit=md.get_double("semblance_lower_limit");
+	double tstart=md.get_double("semblance_window_start");
+	
+	int num_gather=t.member.size();
+	
+	int maxns=0;
+	int maxtrace=0;
+	for(int i=0;i<num_gather;i++)
+		if(t.member[i].ns>maxns)
+		{
+			maxns=t.member[i].ns;
+			maxtrace=i;
+		}
+	
+	vector<double> sembl;
+	sembl.reserve(floor(maxns/wind)*2-1);
+	for(int i=0;i<floor(maxns/wind)*2-1;i++)
+	{
+		//int index=(i+1)*wind/2;
+		//vector<double> stack;
+		//stack.reserve(wind);
+		double normstack=0;
+		for(int j=i*wind/2;j<(i+2)*wind/2;j++)
+		{
+			vector<double> temp;
+			temp.reserve(num_gather);
+			int count=0;
+			for(int k=0;k<num_gather;k++)
+				if(!t.member[k].is_gap(j))
+				{
+					temp.push_back(t.member[k].s[j]);
+					count++;
+				}
+			double median = VectorMedian(temp);
+			double s=median*count;
+			normstack+=s*s;
+		}
+		normstack=sqrt(normstack);
+		
+		vector<double> tnorm;
+		tnorm.reserve(num_gather);
+		for(int j=0;j<num_gather;j++)
+		{
+			double sqsum=0;
+			for(int k=i*wind/2;k<(i+2)*wind/2;k++)
+			{
+				if(!t.member[j].is_gap(k))
+				{
+					double v=t.member[j].s[k];
+					sqsum+=v*v;
+				}
+			}
+			tnorm.push_back(sqrt(sqsum));
+		}
+		
+		sembl.push_back(normstack/(VectorMedian(tnorm)*num_gather));
+	}
+	int asampl=t.member[maxtrace].sample_number(0.0);
+	int samplend=sembl.size()-1;
+	for(int i=ceil(2.0*asampl/wind)-1;i<sembl.size();i++)
+		if(sembl[i]<sembllimit)
+		{
+			samplend=i;
+			break;
+		}
+	double tend=t.member[maxtrace].time((samplend+1)*wind/2);
+	TimeWindow result(tstart,tend);
+	return(result); 
+}
+
+void usage()
+{
+	cerr << "autoxcor db [-o outputdb -e evid -pf pfname]" << endl;
+	exit(-1);
+}
+
+int main(int argc, char **argv)
+{
+	// This is a C++ thing.  Not required on all platforms, but
+	// recommended by all the books.  
+	ios::sync_with_stdio();
+	// This is a standard C construct to crack the command line
+	if(argc<2) usage();
+	string pfin(argv[0]);
+	string dbin(argv[1]);
+	string dbout=dbin;
+	string evidst("NULL");
+	for(int i=2;i<argc;++i)
+	{
+		if(!strcmp(argv[i],"-V"))
+			usage();
+		else if(!strcmp(argv[i],"-pf"))
+		{
+			++i;
+			if(i>=argc) usage();
+			pfin = string(argv[i]);
+		}
+		else if(!strcmp(argv[i],"-o"))
+		{
+			++i;
+			if(i>=argc) usage();
+			dbout=string(argv[i]);
+		}
+		else if(!strcmp(argv[i],"-e"))
+		{
+			++i;
+			if(i>=argc) usage();
+			evidst=string(argv[i]);
+		}
+		else
+			usage();
+	}
+	// Standard Antelope C construct to read a parameter file
+	// Well almost standard.  const_cast is a C++ idiom required
+	// due to a collision of constantness with Antelope libraries.
+	Pf *pf;
+        if(pfread(const_cast<char *>(pfin.c_str()),&pf)) 
+	{
+		cerr << "pfread error for pf file="<<pfin<<".pf"<<endl;
+		exit(-1);
+	}
+	Metadata control(pf);
+	PfStyleMetadata controlpf=pfread(pfin);
+	MetadataList mdens=pfget_mdlist(pf,"Ensemble_mdlist");
+	MetadataList mdtrace=pfget_mdlist(pf,"station_mdlist");
+	MetadataList mdlo=pfget_mdlist(pf,"output_mdlist");
+	MetadataList mdbeam=pfget_mdlist(pf,"Beam_mdlist");
+	try {
+		// Get set of control parameters
+		string netname=control.get_string("netname");
+		string phase=control.get_string("phase");
+		double ts,te;
+		ts=control.get_double("data_window_start");
+		te=control.get_double("data_window_end");
+		TimeWindow datatwin(ts,te);
+		double tpad=control.get_double("data_time_pad");
+		ts=control.get_double("noise_window_start");
+		te=control.get_double("noise_window_end");
+		TimeWindow noise_twin(ts,te);
+		ts=control.get_double("signal_window_start");
+		te=control.get_double("signal_window_end");
+		TimeWindow signal_twin(ts,te);
+		ts=control.get_double("beam_window_start");
+		te=control.get_double("beam_window_end");
+		TimeWindow beamstk_twin_init(ts,te);
+		ts=control.get_double("beam_window_start");
+		te=control.get_double("data_window_end");
+		TimeWindow beam_twin(ts,te+1);
+		//ts=control.get_double("robust_beam_window_start");
+		//te=control.get_double("robust_beam_window_end");
+		//TimeWindow beamrbst_twin(ts,te);
+		double lag_cutoff=control.get_double("lag_cutoff");
+		double laglimit=control.get_double("lag_limit");
+		StationChannelMap stachanmap(pf);
+		string schemain=control.get_string("InputAttributeMap");
+		string schemaout=control.get_string("OutputAttributeMap");
+		double target_dt=control.get_double("target_sample_interval");
+		ResamplingDefinitions rdef(pf);
+		
+		string output_dir=control.get_string("output_dir");
+		
+		// First get all the database components assembled.
+		// input data, output data
+		DatascopeHandle dbh(dbin,false);
+		/* Build a match handle for arrivals using the standard catalog
+		view of the join of event->origin->assoc->arrival */
+		AttributeMap am(schemain);  
+		AttributeMap amo(schemaout);  
+		DatascopeHandle dbcatalog=StandardCatalogView(dbh);
+		list<string> matchkeys;
+		matchkeys.push_back(string("sta"));
+		matchkeys.push_back(string("evid"));
+		DatascopeMatchHandle dbhm(dbcatalog,string(""),matchkeys,am);
+		
+		/* Build a event view to drive the process*/
+		DatascopeHandle dbhv(dbh);
+		dbhv.lookup("event");
+		dbhv.natural_join("origin");
+		dbhv.subset(string("orid==prefor"));
+		
+		/* Define output database*/
+		DatascopeHandle dbho(dbh);
+		if(dbout!=dbin)
+			dbho=DatascopeHandle(dbout,false);
+		dbhv.rewind();
+		ThreeComponentEnsemble *rawdata=NULL;
+		SeismicArray *stations=NULL;
+		/* Assorted variables needed in the loop below */
+		double lat,lon,depth,otime;
+		long evid;
+		long record;
+		list<string> filter_param;
+		// Define the filter
+		try {
+			filter_param=controlpf.get_tbl("filter");
+		} catch (PfStyleMetadataError mdge) {
+			cerr	<<"filter attribute not defined"
+				<<" using default of DEMEAN"<<endl;
+			filter_param.push_back(string("DEMEAN"));
+		}
+		vector<MultiStageFilter> filtlist;
+		for (list<string>::iterator it=filter_param.begin(); it!=filter_param.end(); ++it)
+		{
+			MultiStageFilter filttemp(*it,string(";"));
+			filtlist.push_back(filttemp);
+		}
+		
+		//for now, test only!!
+		//for(int i=0;i<2756;i++) ++dbhv;
+		if(evidst.compare("NULL")!=0)
+		{
+			long idst=atol(evidst.c_str()); 
+			for(int i=0;i<dbhv.number_tuples();++i,++dbhv)
+			{
+				if(dbhv.get_long(string("evid"))==idst)
+				{
+					++dbhv;
+					break;
+				}
+			}
+		}
+		long currecord=dbhv.current_record();
+		for(record=0;record<dbhv.number_tuples()-currecord;++record,++dbhv)
+		{
+			int num_gather;
+			lat=dbhv.get_double(string("origin.lat"));
+			lon=dbhv.get_double(string("origin.lon"));
+			depth=dbhv.get_double(string("origin.depth"));
+			otime=dbhv.get_double(string("origin.time"));
+			evid=dbhv.get_long(string("evid"));
+			// origin coordinates are degrees in the db,
+			// but must be radians for hypocenter object
+			lat=rad(lat);
+			lon=rad(lon);
+			
+			Hypocenter hypo(lat,lon,depth,otime,
+				string("tttaup"),string("iasp91"));
+			// On the first record we need to load the station
+			// geometry object
+			if(record==0)
+			{
+				stations = new SeismicArray(
+					dynamic_cast<DatabaseHandle&>(dbh),
+					hypo.time,netname);
+			}
+			else
+			{
+				TimeWindow test(hypo.time,hypo.time+2000.0);
+				if(!stations->GeometryIsValid(test))
+				{
+					delete stations;
+					stations = new SeismicArray(
+					dynamic_cast<DatabaseHandle&>(dbh),
+					hypo.time,netname);
+				}
+			}
+			// Read the raw data using the time window based constructor
+			try{
+			rawdata=array_get_data(*stations,hypo,
+				phase,datatwin,tpad,dynamic_cast<DatabaseHandle&>(dbh),
+				stachanmap,mdens,mdtrace,am);
+			}catch (SeisppError& serr)
+			{
+				cout<<"bad event"<<endl;
+				serr.log_error();
+				continue;
+			}
+			if(rawdata->member.size()==0)
+			{
+				cout<<"bad event with problem wf data"<<endl;
+				delete rawdata;
+				continue;
+			}
+			PostEvid(rawdata,evid);
+			
+			num_gather=rawdata->member.size();
+			for(int i=0;i<num_gather;i++)
+			{
+				double lat=stations->array[rawdata->member[i].get_string("sta")].lat;
+				double lon=stations->array[rawdata->member[i].get_string("sta")].lon;
+				double elev=stations->array[rawdata->member[i].get_string("sta")].elev;
+				rawdata->member[i].put("lat",lat);
+				rawdata->member[i].put("lon",lon);
+				rawdata->member[i].put("elev",elev);
+			}
+			
+			vector<double> beam_vector;
+			const string arrival_keyword("arrival.time");
+			list<long> data_with_arrivals;
+			data_with_arrivals=LoadArrivalTimes(rawdata->member,dbhm,arrival_keyword);
+			list<long>::iterator index;
+			TimeSeriesEnsemble beam_ensemble;
+			for(index=data_with_arrivals.begin();index!=data_with_arrivals.end();++index)
+			{
+				ThreeComponentSeismogram d=rawdata->member[*index];
+				if(d.live)
+				{
+					try{
+						d.rotate_to_standard();
+						if(control.get_bool("apply_free_surface_transform"))
+						    ApplyFST(d,hypo);
+					}catch (SeisppError& serr){
+						cout<<"Error when rotating record from event: "
+							<<evid<<" station: "<<d.get_string("sta")<<endl;
+						serr.log_error();
+						continue;
+					}catch(...){
+						cout<<"Unexpected error when rotating record from event: "
+							<<evid<<" station: "<<d.get_string("sta")<<endl;
+						continue;
+					}
+					ThreeComponentSeismogram d3c(d);
+					auto_ptr<TimeSeries> beam;
+					auto_ptr<TimeSeries> beampre;
+					beam=auto_ptr<TimeSeries>(ExtractComponent(d,2));
+					if(beam->ns<=0)
+					{
+						cout<<"Number of samples is less than 1 for event: "
+							<<evid<<" station: "<<d.get_string("sta")<<endl;
+						//beam.release();
+						continue;
+					}
+					if( (abs( (beam->dt)-target_dt)/target_dt) > 0.01)
+					{
+					    *beam=ResampleTimeSeries(*beam,rdef,target_dt,false);
+					}
+					double atime=beam->get_double(arrival_keyword);
+					//cout.precision(14);
+					//cout<<"**"<<endl<<d.get_string("sta")<<"	"<<atime<<"**"<<endl;
+					beampre=ArrivalTimeReference(*beam,arrival_keyword,beam_twin);
+                    
+					if(beampre->live)
+					{
+						beampre->put(string("reftime"),atime);
+						beampre->put(moveout_keyword,0.0);
+						//beam->put(snr_keyword,SNR_rms(*beam,signal_twin,noise_twin));
+						beam_ensemble.member.push_back(*beampre);
+					}
+					//beam.release();
+                    //beampre.release();
+				}
+			}
+			delete rawdata;
+			int beamensemblesize=beam_ensemble.member.size();
+			if(beamensemblesize<10)
+			{
+				cout<<"skipped event_id: "<<evid<<endl;
+				continue;
+			}
+			
+			MultichannelCorrelator xcor;
+			vector<MultichannelCorrelator> xcor_v;
+			int reference_member;
+			TimeWindow beamrbst_twin, beamstk_twin;
+			for(vector<MultiStageFilter>::iterator it=filtlist.begin(); it!=filtlist.end(); ++it)
+			{
+				TimeSeriesEnsemble be=beam_ensemble;
+				// Filter the raw data.
+				it->apply(be);
+				
+				for(int i=0;i<beamensemblesize;i++)
+					be.member[i].put(snr_keyword,SNR_rms(be.member[i],signal_twin,noise_twin));
+			
+				beamrbst_twin=SemblanceSearch(be,control);
+				beamstk_twin=beamstk_twin_init;
+				beamstk_twin.end+=beamrbst_twin.end;
+				if(beamstk_twin.end>beam_twin.end)
+					beamstk_twin.end=beam_twin.end;
+				reference_member=0;
+				double maxsnr=be.member[0].get_double(snr_keyword);
+				for(int i=0;i<beamensemblesize;i++)
+					if(be.member[i].get_double(snr_keyword)>maxsnr)
+					{
+						maxsnr=be.member[i].get_double(snr_keyword);
+						reference_member=i;
+					}
+                try{
+				MultichannelCorrelator xcortemp(be, RobustStack, beamstk_twin, beamrbst_twin, lag_cutoff,
+					 RobustSNR, NULL, reference_member);
+				xcor_v.push_back(xcortemp);
+                }catch(...){
+                    cout<<"Unexpected error doing MultichannelCorrelator from event: "
+                    <<evid<<endl;
+                    continue;
+                }
+			}
+			int bestindex=0;;
+			double bestlag=VectorMean(xcor_v[0].lag);
+			for(int i=0;i<xcor_v.size();i++)
+			{
+				double templag=VectorMean(xcor_v[i].lag);
+				if(bestlag>templag)
+				{
+					bestlag=templag;
+					bestindex=i;
+				}
+			}
+			if(bestlag>laglimit)
+				cout<<"Warning: the average lag for event "<<evid<<" is "<<bestlag<<endl;
+				
+			filtlist[bestindex].apply(beam_ensemble);
+			for(int i=0;i<beamensemblesize;i++)
+				beam_ensemble.member[i].put(snr_keyword,SNR_rms(beam_ensemble.member[i],signal_twin,noise_twin));
+			beamrbst_twin=SemblanceSearch(beam_ensemble,control);
+			beamstk_twin=beamstk_twin_init;
+			beamstk_twin.end+=beamrbst_twin.end;
+			if(beamstk_twin.end>beam_twin.end)
+				beamstk_twin.end=beam_twin.end;
+			reference_member=0;
+			double maxsnr=beam_ensemble.member[0].get_double(snr_keyword);
+			for(int i=0;i<beamensemblesize;i++)
+				if(beam_ensemble.member[i].get_double(snr_keyword)>maxsnr)
+				{
+					maxsnr=beam_ensemble.member[i].get_double(snr_keyword);
+					reference_member=i;
+				}
+			xcor=xcor_v[bestindex];
+			
+			for(int i=0;i<beamensemblesize;i++)
+			{
+				double atime=beam_ensemble.member[i].get_double("reftime");
+				beam_ensemble.member[i].rtoa(atime);
+				beam_ensemble.member[i].put(arrival_keyword,atime+xcor.lag[i]);
+				//beam_ensemble.member[i].ator(beam_ensemble.member[i].get_double(arrival_keyword));
+			}
+			
+			TimeSeries beam=xcor.ArrayBeam();
+			
+			long xcorlive=0;
+			for(int i=0;i<beamensemblesize;i++)
+			{
+				if(xcor.xcor.member[i].live)
+					xcorlive++;
+			}
+			if(xcorlive==0)
+				continue;
+			
+			long fold=xcorlive;
+			string filter_beam=beam.get_string("filter_spec");
+			stringstream ss;
+			ss << evid;
+			string beam_dfile = ss.str();
+			beam.put("wfprocess.dir",output_dir);
+			beam.put("dir",output_dir);
+			beam.put("wfprocess.dfile","beam"+beam_dfile);
+			beam.put("wfprocess.endtime",beam.endtime());
+			
+			DatascopeHandle dbxcorbeam(dbho);
+			dbxcorbeam.lookup(string("xcorbeam"));
+			DatascopeHandle dbevlink(dbho);
+			dbevlink.lookup(string("evlink"));
+			DatascopeHandle dbwfprocess(dbho);
+			dbwfprocess.lookup(string("wfprocess"));
+			DatascopeHandle dbarrival(dbho);
+			dbarrival.lookup(string("arrival"));
+			DatascopeHandle dbxcorarrival(dbho);
+			dbxcorarrival.lookup(string("xcorarrival"));
+			DatascopeHandle dbwfdisc(dbho);
+			dbwfdisc.lookup(string("wfdisc"));
+			
+			long recordo=dbsave(beam,dbwfprocess.db,string("wfprocess"),mdbeam,amo);
+			
+			beam.put("sta",beam_ensemble.member[reference_member].get_string("sta"));
+			//beam.put("chan",beam_ensemble.member[reference_member].get_string("chan"));
+			beam.put(string("chan"),string("Z"));
+			beam.put("dfile","beam_wfdisc"+beam_dfile);
+			dbsave(beam,dbwfdisc.db,string("wfdisc"),mdlo,amo);
+			
+			dbwfprocess.db.record=recordo;
+			long pwfid;
+			dbgetv(dbwfprocess.db,0,"pwfid",&pwfid,NULL);
+			double beam_amplitude=beam.get_double(beam_rms_key);
+			recordo=dbaddnull(dbxcorbeam.db);
+            if(recordo==dbINVALID) throw SeisppError(string("dbsave:  dbaddnull failed"));
+            dbxcorbeam.db.record=recordo;
+            dbputv(dbxcorbeam.db,0,"netname",netname.c_str(),
+				"chan","BHZ",
+				"pchan","BZ",
+				"phase",phase.c_str(),
+				"pwfid",pwfid,
+				"filter",filter_beam.c_str(),
+				"robustt0",beamrbst_twin.start,
+				"robusttwin",beamrbst_twin.length(),
+				"fold",fold,
+				"amp",beam_amplitude,
+					NULL);
+			//if(recordo<0)
+			//	cerr << "save_results(Warning):  problems adding to xcorbeam table"<<endl;
+			recordo=dbaddnull(dbevlink.db);
+            if(recordo==dbINVALID) throw SeisppError(string("dbsave:  dbaddnull failed"));
+            dbevlink.db.record=recordo;
+            dbputv(dbevlink.db,0,"evid",evid,"pwfid",pwfid,NULL);
+			
+			int counti=0;
+			for(vector<TimeSeries>::iterator d=beam_ensemble.member.begin();d!=beam_ensemble.member.end();++d,++counti)
+			{
+				if(!xcor.xcor.member[counti].live)
+					continue;
+                recordo=dbaddnull(dbarrival.db);
+                if(recordo==dbINVALID) throw SeisppError(string("dbsave:  dbaddnull failed"));
+                dbarrival.db.record=recordo;
+				dbputv(dbarrival.db,0,"sta",d->get_string("sta").c_str(),
+					"time",d->get_double(arrival_keyword),
+					"arid",d->get_long(arrival_keyword+".arid"),
+					"chan","BHZ",
+					"iphase",phase.c_str(),
+					"snr",d->get_double(snr_keyword),
+					"auth","autoxcor",
+                       NULL);
+                recordo=dbaddnull(dbxcorarrival.db);
+                if(recordo==dbINVALID) throw SeisppError(string("dbsave:  dbaddnull failed"));
+                dbxcorarrival.db.record=recordo;
+				dbputv(dbxcorarrival.db,0,"sta",d->get_string("sta").c_str(),
+					"chan","BHZ",
+					"phase",phase.c_str(),
+					"pwfid",pwfid,
+					"filter",filter_beam.c_str(),
+					"algorithm","autoxcor",
+					"pchan","BZ",
+					"time",d->get_double(arrival_keyword),
+					"twin",beamstk_twin.length(),
+					"samprate",1.0/d->dt,
+					"stackwgt",xcor.weight[counti],
+					"xcorpeak",xcor.peakxcor[counti],
+					"coherence",xcor.amplitude_static[counti],
+					NULL);
+				d->put(string("chan"),string("BHZ"));
+				d->put("dir",output_dir);
+				d->put("dfile","wf"+beam_dfile);
+				//int rnum=dbsave(*d,dbwfdisc.db,string("wfdisc"),mdlo,amo);
+			}
+		}
+		delete stations;
+	}
+	catch (SeisppError& serr)
+	{
+		serr.log_error();
+	}
+	catch (...)
+	{
+		cerr << "Something threw an unexpected exception"<<endl;
+	}
+}
+

--- a/bin/db/autoxcor/autoxcor.pf
+++ b/bin/db/autoxcor/autoxcor.pf
@@ -1,0 +1,203 @@
+
+filter &Tbl{
+DEMEAN;BW 0.5 3 2 3
+}
+
+netname test
+phase P
+data_window_start -40.0
+data_window_end 400.0
+data_time_pad 20.0
+beam_window_start -20.0
+beam_window_end 150.0
+robust_beam_window_start -5.0
+robust_beam_window_end 60.0
+noise_window_start -20.0
+noise_window_end -5.0
+signal_window_start 0.0
+signal_window_end 15.0
+lag_cutoff 5.0
+lag_limit 1.0
+InputAttributeMap css3.0
+OutputAttributeMap css3.0
+target_sample_interval 0.1
+output_dir autoxcor
+apply_free_surface_transform	1
+
+semblance_window 50
+semblance_lower_limit 0.3
+semblance_window_start -5.0
+
+station_mdlist &Tbl{
+sta string
+lat real
+lon real
+elev real
+nsamp int
+samprate real
+datatype string
+dfile string
+dir string
+foff int
+time real
+endtime real 
+timetype string
+}
+
+Ensemble_mdlist &Tbl{
+evid int
+}
+
+Beam_mdlist &Tbl{
+    pwfid int
+    wfprocess.timetype string
+    wfprocess.dir string
+    wfprocess.dfile string
+    wfprocess.algorithm string
+}
+
+output_mdlist &Tbl{
+sta string
+chan string
+nsamp int
+samprate real
+datatype string
+time real
+endtime real 
+dir string
+dfile string
+}
+
+# resammpling recipe
+resample_definitions    &Arr{
+    250 &Arr{
+        Decimator_response_files        &Tbl{
+            5   response/RT72A_5_f
+            5   response/RT72A_5_f
+        }
+        high_limit      251
+        low_limit       249
+    }
+    200 &Arr{
+        Decimator_response_files        &Tbl{
+            5   response/RT72A_5_f
+            4   response/RT72A_4_f
+        }
+        high_limit      201
+        low_limit       199
+    }
+    120 &Arr{
+        Decimator_response_files        &Tbl{
+            0.75      resample
+            4   response/RT72A_4_f
+            4   response/RT72A_4_f
+        }
+        high_limit      121
+        low_limit       119
+    }
+    100 &Arr{
+        Decimator_response_files        &Tbl{
+            5   response/RT72A_5_f
+            2   response/RT72A_2_f
+        }
+        high_limit      101
+        low_limit       99
+    }
+    80  &Arr{
+        Decimator_response_files        &Tbl{
+            4       response/RT72A_4_f
+            2       response/RT72A_2_f
+        }
+        high_limit      81
+        low_limit       79
+    }
+    50  &Arr{
+        Decimator_response_files        &Tbl{
+            5       response/RT72A_5_f
+        }
+        high_limit      51
+        low_limit       49
+    }
+    25  &Arr{
+        Decimator_response_files        &Tbl{
+            0.5      resample
+            5       response/RT72A_5_f
+        }
+        high_limit      26
+        low_limit       24
+    }
+    20  &Arr{
+        Decimator_response_files        &Tbl{
+            2       response/RT72A_2_f
+        }
+        high_limit      21
+        low_limit       19
+    }
+    33.5        &Arr{
+        Decimator_response_files        &Tbl{
+            0.8375      resample
+            4       response/RT72A_4_f
+        }
+        high_limit      34.5
+        low_limit       32.5
+    }
+    40  &Arr{
+        Decimator_response_files        &Tbl{
+            4       response/RT72A_4_f
+        }
+        high_limit      41
+        low_limit       39
+    }
+}
+
+# Used to construct StationChannelMap object
+StationChannelMap       &Arr{
+    default     &Tbl{
+        BHE 0 0
+        BHN 1 0
+        BHZ 2 0
+        HHE 0 1
+        HHN 1 1
+        HHZ 2 1
+        LHE 0 2
+        LHN 1 2
+        LHZ 2 2
+        BH1 0 3
+        BH2 1 3
+        BH3 2 3
+        BH1_00 0 5
+        BH2_00 1 5
+        BHZ_00 2 5
+        BHE_00 0 6
+        BHN_00 1 6
+        BHE_01 0 7
+        BHN_01 1 7
+        BHZ_01 2 7
+        BHE_10 0 8
+        BHN_10 1 8
+        BHZ_10 2 8
+        BHE_HR 0 9
+        BHN_HR 1 9
+        BHZ_HR 2 9
+        BH1_10 0 10
+        BH2_10 1 10
+        BH1_60 0 11
+        BH2_60 1 11
+        BHZ_60 2 11
+        BH1_HR 0 12
+        BH2_HR 1 12
+        HH1 0 13
+        HH2 1 13
+        HH1_00 0 14
+        HH2_00 1 14
+        HH1_10 0 15
+        HH2_10 1 15
+        HHZ_10 2 15
+        HHE_00 0 16
+        HHN_00 1 16
+        HHZ_00 2 16
+        HHE_01 0 17
+        HHN_01 1 17
+        HHZ_01 2 17
+    }
+}

--- a/lib/graphics/libseiswplot/SeismicPlot.cc
+++ b/lib/graphics/libseiswplot/SeismicPlot.cc
@@ -250,7 +250,8 @@ void SeismicPlot::plot(TimeSeriesEnsemble& d,bool block_for_event)
             block_till_exit_pushed=true;
         else
             block_till_exit_pushed=false;
-        cerr <<"starting event handler"<<endl;
+        //DEBUG
+        //cerr <<"starting event handler"<<endl;
         if(!EventLoopIsActive) 
             this->launch_Xevent_thread_handler();
     }

--- a/lib/graphics/libseiswplot/TimeWindowPicker.cc
+++ b/lib/graphics/libseiswplot/TimeWindowPicker.cc
@@ -5,7 +5,7 @@ namespace SEISPP {
 
 void pick_tw_callback(Widget w, XtPointer client_data, XtPointer userdata)
 {
-    cerr << "Entering pick_tw_callback"<<endl;
+    //cerr << "Entering pick_tw_callback"<<endl;
     TimeWindowPicker *picker_handle=reinterpret_cast<TimeWindowPicker*>
         (client_data);
     TimeWindow twinpicked;
@@ -29,24 +29,21 @@ void pick_tw_callback(Widget w, XtPointer client_data, XtPointer userdata)
     if(spick->type == WINDOW) 
         picker_handle->setpick(twinpicked);
 
-    cerr << "Leaving pick_tw_callback"<<endl;
+    //cerr << "Leaving pick_tw_callback"<<endl;
 }
 void arm_tw_pick_callback(Widget w, 
         XtPointer client_data, XtPointer userdata)
 {
-    cerr << "Entering arm_tw_pick_callback"  <<endl;
+    //cerr << "Entering arm_tw_pick_callback"  <<endl;
     TimeWindowPicker *picker_handle=reinterpret_cast<TimeWindowPicker*>
         (client_data);
     picker_handle->enable_blocking();
-    //DEBUG - try preset of markers
-    TimeWindow tmp(5.0,30.0);
-    picker_handle->setpick(tmp);
     picker_handle->enable_picking();
-    cerr << "Exiting arm_tw_pick_callback"  <<endl;
+    //cerr << "Exiting arm_tw_pick_callback"  <<endl;
 }
 void TimeWindowPicker::enable_picking()
 {
-    cerr << "Entering enable_picking"  <<endl;
+    //cerr << "Entering enable_picking"  <<endl;
     this->block_till_exit_pushed=true;
     int k,kmax;
     if(ThreeComponentMode)
@@ -55,11 +52,12 @@ void TimeWindowPicker::enable_picking()
         kmax=1;
     for(k=0;k<kmax;++k)
     {
-        cerr << "Adding callbacks for seisw widget number "<<k<<endl;
+        //cerr << "Adding callbacks for seisw widget number "<<k<<endl;
         XtRemoveAllCallbacks(seisw[k],ExmNbtn3Callback);
         XtAddCallback(seisw[k],ExmNbtn3Callback,pick_tw_callback,(XtPointer)this);
     }
     //DEBUG - using routine from internet search
+    /*
     for(k=0;k<kmax;++k)
     {
         cerr << "Testing seisw widget number "<<k<<endl;
@@ -83,7 +81,8 @@ void TimeWindowPicker::enable_picking()
                 cerr << "Returned unrecognized value"<<endl;
         };
     }
-    cerr << "Exiting enable_picking"  <<endl;
+    */
+    //cerr << "Exiting enable_picking"  <<endl;
 }
 TimeWindowPicker::TimeWindowPicker() : SeismicPlot(), picked_window()
 {
@@ -93,10 +92,10 @@ TimeWindowPicker::TimeWindowPicker() : SeismicPlot(), picked_window()
 TimeWindowPicker::TimeWindowPicker(Metadata& md) : SeismicPlot(md) ,
     picked_window()
 {
-    cerr << "Entering TimeWindowPicker(Metadata) constructor"<<endl;
+    //cerr << "Entering TimeWindowPicker(Metadata) constructor"<<endl;
     build_pick_menu();
     pick_completed=false;
-    cerr << "Exiting TimeWindowPicker(Metadata) constructor"<<endl;
+    //cerr << "Exiting TimeWindowPicker(Metadata) constructor"<<endl;
 }
 TimeWindow TimeWindowPicker::get()
 {
@@ -128,7 +127,7 @@ void TimeWindowPicker::build_pick_menu()
 }
 void TimeWindowPicker::setpick(TimeWindow twinpicked)
 {
-    cerr << "Entering setpick"<<endl;
+    //cerr << "Entering setpick"<<endl;
     picked_window=twinpicked;
     pick_completed=true;
     // freeze this for now
@@ -141,6 +140,6 @@ void TimeWindowPicker::setpick(TimeWindow twinpicked)
         kmax=1;
     for(k=0;k<kmax;++k)
         XtVaSetValues(this->seisw[k],ExmNdisplayMarkers,&markers,NULL);
-    cerr << "Leaving setpick"<<endl;
+    //cerr << "Leaving setpick"<<endl;
 }
 } // End SEISPP namespace encapsulation

--- a/lib/seismic/libseispp/MultichannelCorrelator.h
+++ b/lib/seismic/libseispp/MultichannelCorrelator.h
@@ -45,18 +45,6 @@ containing no data.  The caller should test for this condition by examining the
 live variable of the output.  The trace will be marked live if the correlation was
 successful, but live will be false if gaps were detected and correlation failed. 
 \par
-A more subtle problem with gaps arises if on of the inputs (x or y) has a gap at
-the beginning or end of the time window to be processed.  In the seispp library
-this type of situation is not always flagged as a gap because it can happen 
-naturally when, for example, dealing with segmented data derived either from
-a triggered instrument or extraction from continuous data.  This situation is 
-handled by testing the feasibility of the correlation by examining the size
-of x and y.  If x is shorter than y this function returns a null seismogram
-with no data and marked dead.  Thus, just as with an internal gap the caller
-must handle this situation and always test for a return marked dead.
-If SEISPP_verbose is true an error announcing this will be pushed to stderr.
-Otherwise this potential error situation is done silently.
-\par
 Although the procedure does not test this it makes a somewhat implicit assumption the
 data have been converted to a relative time reference frame.  This was done to make
 the procedure work with both common source and common receiver gathers (receiver
@@ -137,6 +125,49 @@ ator method of the TimeSeries object.
 */
 TimeSeries correlation(TimeSeries& x, TimeSeries& y,
 		TimeWindow cwin, bool normalize=false);
+/*! \brief Cross-correlation procedure for ThreeComponentSeismogram  objects.
+
+This is procedure computes the cross correlation in a vector sense between
+two ThreeComponentSeismogram object.  It is conceptually similar to the 
+similar procedures in defined in this library for TimeSeries objects.
+In fact the implementation was produced by simply editing the algorithm for
+TimeSeries objects.   Vector correlation is computed as the dot product
+between x and y at variable lag summed for all three components.   
+The correlation interval is defined by the length of the two components.
+The input x MUST be shorter than y or the procedure will throw and 
+exception.  The range of lags is defined by the samples x can fit in y.
+\par 
+This procedure checks for gaps in the correlation window of y.  
+It also checks for any gaps in x  If any gaps are present
+the procedure returns immediately with a default TimeSeries object 
+containing no data and marked dead.  The caller should test for this condition by examining the 
+live variable of the output.  The trace will be marked live if the correlation was
+successful, but live will be false if gaps were detected and correlation failed. 
+\par
+Although the procedure does not test this it makes a somewhat implicit assumption the
+data have been converted to a relative time reference frame.  This was done to make
+the procedure work with both common source and common receiver gathers (receiver
+array versus source array processing to those not as familiar with the exploration
+geophysics jargon).  Have the correlator defined on an absolute time base is 
+particularly problematic. Hence, before calling this function create a relative 
+time reference data set using something like ArrivalTimeReference or force each 
+trace passed through this procedure to have a relative time base using the 
+ator method of the TimeSeries object.
+
+\return A new TimeSeries object containing the cross-correlation function.  
+	The correlation trace contains a copy of the Metadata of the correlated (y)
+	trace.  Be warned that this may leave some relics in this object's 
+	Metadata that are not correct.
+\param x correlator function (i.e. this is the trace that is shifted in the operation).
+\param y data to correlate x against.  The length of y must be more than x or an error
+	will be thrown.
+\param normalize if true the output is normalized by the L2 norm of x and y in the
+    correlation window (3C L2 norm means sum of a global sum of squares across components)..  
+
+\exception SeisppError is thrown if sample rates of x and y do not match 
+*/
+TimeSeries correlation(ThreeComponentSeismogram& x, 
+        ThreeComponentSeismogram& y,bool normalize=false);
 
 /*! \brief Encapsulates data defining the peak of a cross-correlation function.
 *

--- a/lib/seismic/libseispp/ThreeComponentSeismogram.cc
+++ b/lib/seismic/libseispp/ThreeComponentSeismogram.cc
@@ -956,6 +956,44 @@ void ThreeComponentSeismogram::rotate(double nu[3])
 	SphericalCoordinate xsc=UnitVectorToSpherical(nu);
 	this->rotate(xsc);
 }
+/* simplified procedure to rotate only zonal angle by phi radians. 
+ Similar to above but using only azimuth angle AND doing a simple
+ rotation in the horizontal plane.  Efficient algorithm only 
+ alters 0 and 1 components. */
+void ThreeComponentSeismogram::rotate(double phi)
+{
+	if( (ns<=0) || !live) return; // do nothing in these situations
+	int i;
+	double a,b;
+        /* Restore to cardinate coordinates */
+        this->rotate_to_standard();
+        a=cos(phi);
+        b=sin(phi);
+	tmatrix[0][0] = a;
+	tmatrix[1][0] = b;
+	tmatrix[2][0] = 0.0;
+	tmatrix[0][1] = -b;
+	tmatrix[1][1] = a;
+	tmatrix[2][1] = 0.0;
+	tmatrix[0][2] = 0.0;
+	tmatrix[1][2] = 0.0;
+	tmatrix[2][2] = 1.0;
+
+        /* Now multiply the data by this transformation matrix.  
+         Not trick in this i only goes to 2 because 3 component
+         is an identity.*/
+	double *work[2];
+	for(i=0;i<2;++i)work[i] = new double[ns];
+	for(i=0;i<2;++i)
+	{
+		dcopy(ns,u.get_address(0,0),3,work[i],1);
+		dscal(ns,tmatrix[i][0],work[i],1);
+		daxpy(ns,tmatrix[i][1],u.get_address(1,0),3,work[i],1);
+	}
+	for(i=0;i<2;++i) dcopy(ns,work[i],1,u.get_address(i,0),3);
+	components_are_cardinal=false;
+	for(i=0;i<2;++i) delete [] work[i];
+}
 void ThreeComponentSeismogram::apply_transformation_matrix(double a[3][3])
 {
 	if( (ns<=0) || !live) return; // do nothing in these situations

--- a/lib/seismic/libseispp/ThreeComponentSeismogram.h
+++ b/lib/seismic/libseispp/ThreeComponentSeismogram.h
@@ -322,6 +322,18 @@ method defined below.
 \param nu defines direction of x3 direction (longitudinal) as a unit vector with three components.
 **/
 	void rotate(double nu[3]);
+        /*! \brief Rotate horizontals by a simple angle in degrees.
+
+          A common transformation in 3C processing is a rotation of the 
+          horizontal components by an angle.  This leaves the vertical
+          (assumed here x3) unaltered.   This routine rotates the horizontals
+          by angle phi using with positive phi counterclockwise as in 
+          polar coordinates and the azimuth angle of spherical coordinates.
+
+          \param phi rotation angle around x3 axis in counterclockwise
+            direction (in radians).
+            */
+        void rotate(double phi);
 	// This applies a general transform with a 3x3 matrix.  
 	// User should set components_are_orthogonal true if they
 	// are so after this transformation.  The default assumes not

--- a/lib/seismic/libseispp/correlation.cc
+++ b/lib/seismic/libseispp/correlation.cc
@@ -178,6 +178,8 @@ TimeSeries correlation(ThreeComponentSeismogram& x, ThreeComponentSeismogram& y,
 	int lz=ly-lx;
 	TimeSeries z(dynamic_cast<Metadata&>(y),false);
         z.s.reserve(lz);
+        /* Necessary to initialize stl container this way */
+        for(i=0;i<lz;++i) z.s.push_back(0.0);
 	z.t0=y.t0-x.t0;
 	z.dt=x.dt;  // probably not necessary, but forced initialization always good.
 	z.ns=lz;

--- a/lib/seismic/libseispp/correlation.cc
+++ b/lib/seismic/libseispp/correlation.cc
@@ -143,5 +143,65 @@ TimeSeries correlation(TimeSeries& x, TimeSeries& y,TimeWindow lag_range, bool n
 	}
 	return z;
 }
+TimeSeries correlation(ThreeComponentSeismogram& x, ThreeComponentSeismogram& y,
+        bool normalize)
+{
+	int i,k;
+	int lx,ly;
+	const string base_message("ThreeComponentSeismogra Correlation procedure:  ");
+
+	/* This assumes default constructors marks null trace dead */
+	if(!(x.live) || !(y.live) || x.has_gap() || y.has_gap()) return (TimeSeries());
+        lx=x.u.columns();
+        ly=y.u.columns();
+	if(ly<lx)
+	{
+	    if(SEISPP_verbose)
+	    {
+		cerr << base_message << "cannot compute cross correlation. "<<endl
+			<<"Number samples in target less than samples in correlator waveform"<<endl
+			<<"Correlator returns an empty (dead) ThreeComponentSeismogram object."<<endl;
+	    }
+	}
+	/* this comes from seispp and is used to regular question of
+	if sample rates match to some tolerance */
+	if(!SampleIntervalsMatch<ThreeComponentSeismogram>(x,y.dt) )
+	{
+		throw SeisppError(base_message+string(" sample rates do not match"));
+	}
+        /* We clone the correlation metadata from y.  This will leave debris since
+           the output is a TimeSeries and the parent is a ThreeComponentSeismogram.
+           Could cause downstream problems, but fixing would require a messy
+           editing. */
+	int lz=ly-lx;
+	TimeSeries z(dynamic_cast<Metadata&>(y),false);
+        z.s.reserve(lz);
+	z.t0=y.t0-x.t0;
+	z.dt=x.dt;  // probably not necessary, but forced initialization always good.
+	z.ns=lz;
+        /* Vector cross-correlation.   sum a each lag allows this simple formula
+           using ddot */
+	for(i=0;i<lz;++i)
+	{
+            z.s[i]=0.0;
+            for(k=0;k<3;++k)
+                z.s[i]+=ddot(lx,x.u.get_address(k,0),3,y.u.get_address(k,i),3);
+	}
+	if(normalize)
+	{
+                /* Caution - this depends upon a detail of how
+                   u is stored. In dmatrix object data are stored
+                   in a contiguous array and this assumes that*/
+		double nrmx=dnrm2(3*lx,x.u.get_address(0,0),1);
+		double nrmy;
+		for(i=0;i<lz;++i)
+		{
+			nrmy=dnrm2(3*lx,y.u.get_address(0,i),1);
+			z.s[i]/= (nrmx*nrmy);
+		}
+	}
+	return z;
+}
+		
 		
 } // End SEISPP namespace declaration

--- a/lib/seismic/libseispp/correlation.cc
+++ b/lib/seismic/libseispp/correlation.cc
@@ -57,6 +57,7 @@ TimeSeries correlation(TimeSeries& x, TimeSeries& y,bool normalize)
 			z.s[i]/= (nrmx*nrmy);
 		}
 	}
+        z.live=true;
 	return z;
 }
 		
@@ -141,6 +142,7 @@ TimeSeries correlation(TimeSeries& x, TimeSeries& y,TimeWindow lag_range, bool n
 			}
 		}
 	}
+        z.live=true;
 	return z;
 }
 TimeSeries correlation(ThreeComponentSeismogram& x, ThreeComponentSeismogram& y,
@@ -200,6 +202,7 @@ TimeSeries correlation(ThreeComponentSeismogram& x, ThreeComponentSeismogram& y,
 			z.s[i]/= (nrmx*nrmy);
 		}
 	}
+        z.live=true;
 	return z;
 }
 		

--- a/lib/seismic/libseispp/ensemble_helpers.cc
+++ b/lib/seismic/libseispp/ensemble_helpers.cc
@@ -97,18 +97,24 @@ auto_ptr<TimeSeriesEnsemble> ExtractComponent(ThreeComponentEnsemble& tcs,int co
 		TimeSeriesEnsemble(dynamic_cast<Metadata&>(tcs),tcs.member.size()));
 	for(tcsp=tcs.member.begin();tcsp!=tcs.member.end();++tcsp)
 	{
-		// silently skip anything that throws an exception.  
-		// sanity test at end to throw an exception if the result is empty
 		try {
 			
 			x=ExtractComponent(*tcsp,component);
 			result->member.push_back(*x);
 			delete x;
-		} catch(...){};
+		} catch(SeisppError& serr)
+                {
+                    if(SEISPP_verbose)
+                        serr.log_error();
+                }
+                catch(...){
+                    cerr << "ExtractComponent:  "
+                        <<"Something threw an undefined exception"<<endl;
+                }
 	}
 	if(result->member.size()<=0)
 		throw SeisppError(
-			string("SEISPP::ExtractComponent ThreComponentEnsemble procedure: ")
+			string("SEISPP::ExtractComponent ThreeComponentEnsemble procedure: ")
 			+ string("Output TimeSeriesEnsemble is empty."));
 	return(result);
 }
@@ -147,6 +153,9 @@ void BundleChannels(TimeSeriesEnsemble& rawdata, ThreeComponentEnsemble& dtcs,
     int i,j;
     int rawsize=rawdata.member.size();
     try{
+        if(SEISPP_verbose)
+            cout << "BundleChannels procedure:  attempting to assemble "
+                << rawdata.member.size()<<" channels into 3C bundles"<<endl;
         /* Sort the data by sta chan for the algorithm here to work */
         StaChanSort(rawdata);
         //initialize before loop - assumes rawdata not empty 
@@ -172,7 +181,7 @@ void BundleChannels(TimeSeriesEnsemble& rawdata, ThreeComponentEnsemble& dtcs,
                   serr.log_error();
                 }
             }
-            else if( (nextsta!=current_sta) || (i>=rawsize-1) )
+            if( (nextsta!=current_sta) || (i>=rawsize-1) )
             {
                 try {
                 /*Always dangerous to decement a loop counter but
@@ -265,6 +274,10 @@ void BundleChannels(TimeSeriesEnsemble& rawdata, ThreeComponentEnsemble& dtcs,
                 current_sta=nextsta;
             }
         }
+        if(SEISPP_verbose)
+            cout << "BundleChannels procedure:  "
+                << "ensemble number of 3C stations assembled="
+                << dtcs.member.size()<<endl;
     }catch(...){throw;};
 }
 #endif

--- a/lib/utility/libgclgrid/create_destroy.cc
+++ b/lib/utility/libgclgrid/create_destroy.cc
@@ -954,7 +954,8 @@ GCLvectorfield3d::GCLvectorfield3d(GCLgrid3d& g, int n4)
 					val[i][j][k][l]=0.0;
 }
 /* File based constructors for field objects */
-GCLscalarfield::GCLscalarfield(string fname, string format)
+GCLscalarfield::GCLscalarfield(string fname, string format,
+        bool enforce_object_type)
     : GCLgrid(fname,format)
 {
     const string base_error("GCLscalarfield file constructor:  ");
@@ -965,6 +966,8 @@ GCLscalarfield::GCLscalarfield(string fname, string format)
                Inefficent but assumption is large number of these
                objects are not going to be created by this mechanism. */
             Metadata params=pfload_GCLmetadata(fname);
+            if(enforce_object_type)
+            {
             string otype=params.get_string("object_type");
             string otypethis=string(typeid(*this).name());
             if(otype!=otypethis)
@@ -972,6 +975,7 @@ GCLscalarfield::GCLscalarfield(string fname, string format)
                + "Object type mismatch.  "
                + "Called GCLscalarfield constructor on a file with object_type="
                + otype);
+            }
             string dfile=fname+"."+dfileext;
             FILE *fp=fopen(dfile.c_str(),"r");
             if(fp==NULL)
@@ -1054,7 +1058,8 @@ GCLscalarfield3d::GCLscalarfield3d(string fname, string format)
 
     }catch(...){throw;};
 }
-GCLvectorfield::GCLvectorfield(string fname, string format)
+GCLvectorfield::GCLvectorfield(string fname, string format,
+        bool enforce_object_type)
     : GCLgrid(fname,format)
 {
     const string base_error("GCLvectorfield file constructor:  ");
@@ -1062,6 +1067,8 @@ GCLvectorfield::GCLvectorfield(string fname, string format)
         if(format==default_output_format)
         {
             Metadata params=pfload_GCLmetadata(fname);
+            if(enforce_object_type)
+            {
             string otype=params.get_string("object_type");
             string otypethis=string(typeid(*this).name());
             if(otype!=otypethis)
@@ -1069,6 +1076,7 @@ GCLvectorfield::GCLvectorfield(string fname, string format)
                + "Object type mismatch.  "
                + "Called GCLvectorfield constructor on a file with object_type="
                + otype);
+            }
             /* nv has to be handled specially.  attribute name maintenance
                issue here */
             nv=params.get_int("nv");

--- a/lib/utility/libgclgrid/gclgrid.h
+++ b/lib/utility/libgclgrid/gclgrid.h
@@ -446,18 +446,12 @@ public:
             (current default is a two file output separating the 
             header and data.  Hence users should avoid .ext
             file names like myfile.dat.)
-          \parm enforce_object_type is used to turn type checking 
-          on an off.   When true (default) file object type must 
-          match the type of the constructor.   Useful for subclasses
-          in some situations and to read a grid linked to a field
-          ignoring the field data.
 
 
           \exception GCLgridError is throw if save fails.
         */
         void save(string fname, string dir, 
-                string format=default_output_format,
-                bool enforce_object_type=true);
+                string format=default_output_format);
 	/*! 
 	// Find the index position of a point in a GCLgrid.  
 	// This is a low level function to find the location of a point

--- a/lib/utility/libgclgrid/gclgrid.h
+++ b/lib/utility/libgclgrid/gclgrid.h
@@ -394,6 +394,7 @@ public:
           file used to store the actual data. Most applications will 
           likely want to force default and use only one argument to
           this constructor.
+
           */
         GCLgrid(string fname, string format=default_output_format);
 /*! Standard copy constructor.*/
@@ -445,11 +446,18 @@ public:
             (current default is a two file output separating the 
             header and data.  Hence users should avoid .ext
             file names like myfile.dat.)
+          \parm enforce_object_type is used to turn type checking 
+          on an off.   When true (default) file object type must 
+          match the type of the constructor.   Useful for subclasses
+          in some situations and to read a grid linked to a field
+          ignoring the field data.
+
 
           \exception GCLgridError is throw if save fails.
         */
         void save(string fname, string dir, 
-                string format=default_output_format);
+                string format=default_output_format,
+                bool enforce_object_type=true);
 	/*! 
 	// Find the index position of a point in a GCLgrid.  
 	// This is a low level function to find the location of a point
@@ -879,8 +887,14 @@ public:
           file used to store the actual data. Most applications will 
           likely want to force default and use only one argument to
           this constructor.
+          \parm enforce_object_type is used to turn type checking 
+          on an off.   When true (default) file object type must 
+          match the type of the constructor.   Useful for subclasses
+          in some situations and to read a grid linked to a field
+          ignoring the field data.
           */
-        GCLscalarfield(string fname, string format=default_output_format);
+        GCLscalarfield(string fname, string format=default_output_format,
+                bool enforce_object_type=true);
 	/*! 
 	// Destructor.  
 	// Nontrivial destructor as it has to destroy components
@@ -1072,8 +1086,14 @@ public:
           file used to store the actual data. Most applications will 
           likely want to force default and use only one argument to
           this constructor.
+          \parm enforce_object_type is used to turn type checking 
+          on an off.   When true (default) file object type must 
+          match the type of the constructor.   Useful for subclasses
+          in some situations and to read a grid linked to a field
+          ignoring the field data.
           */
-        GCLvectorfield(string fname, string format=default_output_format);
+        GCLvectorfield(string fname, string format=default_output_format,
+                bool enforce_object_type=true);
 	/** Standard assignment operator. */
 	GCLvectorfield& operator=(const GCLvectorfield&);
 	/*! 


### PR DESCRIPTION
The most significant change in this group of changes to the seispp library is a bug fix for a procedure that is used to assembled 3C bundles when loading a time window of data.  The previous version had an off by one error that caused it to ALWAY drop the last station it processed.   Users of dbxcor should be aware of this fix as if you are running in the mode to require 3C data you will drop data.   

Another major change is an interface change to the ThreeComponentSeismgram object.  I added a simple rotate procedure that only rotates horizontals by a specified angle.  This should be part of the basic API for this object, BUT it means any code using 3C data must be recompiled to deal with the API change.   

Finally I've added a new three component, vector cross correlation procedure.   