### PR TITLE
Change how cleanup works in dbmoment

### DIFF
--- a/bin/db/dbmoment/Makefile
+++ b/bin/db/dbmoment/Makefile
@@ -26,10 +26,9 @@ include $(ANTELOPEMAKE)
 
 DIRS = DREGERS_MTPACKAGE MODELS EXAMPLE_CODE
 
-prep_distro:
+clean_mtpackage:
 	@echo "Clean DBMOMENT directory structure."
 	$(RM) -rf DREGERS_MTPACKAGE/C_CODE
 	$(RM) -rf DREGERS_MTPACKAGE/GETPAR
 
-dbmoment: prep_distro
-	produce -v dbmoment
+clean :: clean_mtpackage


### PR DESCRIPTION
prep_distro rule was poorly named, and overriding the dbmoment target
breaks the Antelope contrib xpy rule.

Converted the rule to be a dependency on the clean target.