### PR TITLE
Update slink2orb, add option -mbi and new libslink

### DIFF
--- a/bin/rt/slink2orb/ChangeLog
+++ b/bin/rt/slink2orb/ChangeLog
@@ -1,3 +1,10 @@
+7 August 2018
+  - Update to libslink to 2.6.
+  - Add -mbi option to match byte order of integer encoded data to
+      the same byte order as the miniSEED header, swapping the data
+      payload if needed.
+  - version 4.3.
+
 6 July 2015
   - Update to libslink to 2.4b.
   - Small fix to logging shim functions to avoid compiler warnings.

--- a/bin/rt/slink2orb/libslink/.clang-format
+++ b/bin/rt/slink2orb/libslink/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: LLVM
+AlwaysBreakAfterDefinitionReturnType: TopLevel
+SpaceBeforeParens: Always
+BreakBeforeBraces: Allman
+AlignConsecutiveAssignments: true
+ColumnLimit: 0

--- a/bin/rt/slink2orb/libslink/ChangeLog
+++ b/bin/rt/slink2orb/libslink/ChangeLog
@@ -1,3 +1,25 @@
+2016.290: version 2.6
+	- Change host name resolution to use getaddrinfo() on all platforms
+	except Windows.  Support is now nearly ubiquitous.  Still limited to
+	IPv4 addresses.
+	- Add Cygwin target to platforms and cleanup platform support.
+
+2016.288:
+	- Replace data sample unpacking routines from qlib2 with new routines
+	developed from scratch in libmseed.  All code is now LGPL licensed.
+	- Add sl_msr_srcname() function to generate "Net_Sta_Loc_Chan[_Qual]".
+	- Switch to simpler SOCKET type defined as needed by platform includes
+	or as int when not set.
+	- Clarify licensing to be LGPLv3.
+	- Cleanup Makefile (remove unused targets) and README, add INSTALL.
+
+2016.287: version 2.5
+	- Support data sample unpacking with byte order specified in Blockette 1000,
+	specifically allows little endian decoding.  Thanks to patch by Yen Soon.
+	- Port socket usage to portable SLP_SOCKET type, either int or SOCKET.
+	- Change default use of lastpkttime to true (1) in sl_newslcd().
+	- Quiet some MSVC warnings with a define suggested by Kevin Frechette.
+
 2013.305: version 2.4b
 	- sl_read_streamlist(): Allow '!' character in selectors field, this
 	is allowed to negate selector(s).  This routine is only used when

--- a/bin/rt/slink2orb/libslink/INSTALL
+++ b/bin/rt/slink2orb/libslink/INSTALL
@@ -1,52 +1,35 @@
 
-Installation instructions for libslink: the SeedLink client library.
+The library requires that C99 integer types are available on the
+target computer.  Specifically the int8_t, int16_t, int32_t, int64_t
+and their unsigned counterpart types.  If these data types are not
+available guesses are made in lmplatform.h.
 
--- Building --
+-- Unix --
 
-Unix/Linux: The easiest way to compile the library is to simply run
-'make'.  The included Makefile should work for most Unix-like
-environments with GNU's gcc.  The Makefile will need to be edited to
-use a different compiler (e.g. the Sun compiler), instructions are
-included in the Makefile.  By default a statically linked version of
-the library is built 'libslink.a'.  Using gcc it is possible to build
-a shared library with 'make shared'.
+A simple 'make' on most Unix-like systems should build the library.
 
-Windows: On a WIN32 platform the library can be compiled by using the
+The included Makefile should work for most Unix-like environments and
+most make variants; it is know to work with GNU make.
+
+The CC and CFLAGS environment variables can be set to control the build.
+
+By default a statically linked version of the library is built: 'libslink.a'.
+
+With GCC, clang or compatible build tools it is possible to build a shared
+library with 'make shared'.
+
+-- macOS --
+
+A static library can be compiled using the above Unix instructions,
+just run 'make'.
+
+Using GCC, clang or compatible build tools it is possible to build a dynamic
+library with 'make dynamic'.
+
+-- Windows (Win32) --
+
+On a WIN32 platform the library can be compiled by using the
 Nmake compatible Makefile.win (e.g. 'nmake -f Makefile.win') or Open
 Watcom's Wmake with Makefile.wat (e.g. 'wmake -f Makefile.wat'). The
 default target is a static library 'libslink.lib'.  The library has
-been tested with Microsoft Visual Studio 6 and Open Watcom 1.1.
-
-For non-WIN32 platforms the POSIX nanosleep() function is used.  This
-function may not be implemented on older Solaris or Linux platforms.
-It is known to be available under Solaris 8 or later and recent
-versions of Glibc2.
-
--- Installing --
-
-For installation into the system development environment simply copy
-the library (libslink.a and/or libslink.so) into a system library
-directory and copy the associated libslink.h into a system include
-directory.  Otherwise the library and include file can be used
-directly from the build directory.
-
-The 'example' directory includes an example SeedLink client that uses
-libslink.
-
-The 'doc' directory includes all associated documentation including
-a Users Guide and man pages for library functions.
-
--- Threading --
-
-The library is thread-safe under Unix-like environments with the
-condition that each connection descriptor (SLCD) is handled by a
-single thread.  Thread independent logging schemes are possible.
-Under WIN32 the library is not thread-safe.
-
--- Pronounciation --
-
-lib = 'l' + [eye] + 'b'  (as in library, long 'i')
-s = [es]   (like the beginning of 'esta' in como esta?)
-link = link   (rhymes with the color pink)
-
-all together: 'l' [eye] 'b' [es] link
+been tested with Open Watcom 1.8.

--- a/bin/rt/slink2orb/libslink/LICENSE.txt
+++ b/bin/rt/slink2orb/libslink/LICENSE.txt
@@ -1,0 +1,847 @@
+libmseed is licensed under the LGPL v3.0, i.e. it is licensed with the GPL v3.0
+and the additional set of permissions granted by the LGPL v3.0 license. This
+file contains both licenses.
+
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.
+
+
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/bin/rt/slink2orb/libslink/Makefile
+++ b/bin/rt/slink2orb/libslink/Makefile
@@ -4,22 +4,24 @@
 #   CC : Specify the C compiler to use
 #   CFLAGS : Specify compiler options to use
 
-# GCC specific parameters
-GCC = gcc
-GCCFLAGS = -O2 -Wall
+MAJOR_VER = 2
+MINOR_VER = 6
+CURRENT_VER = $(MAJOR_VER).$(MINOR_VER)
+COMPAT_VER = $(MAJOR_VER).$(MINOR_VER)
 
-LIB_OBJS = gswap.o unpack.o msrecord.o genutils.o strutils.o \
-           logging.o network.o statefile.o config.o \
-           globmatch.o slplatform.o slutils.o
+LIB_SRCS = gswap.c unpack.c msrecord.c genutils.c strutils.c \
+           logging.c network.c statefile.c config.c \
+           globmatch.c slplatform.c slutils.c
 
-CURRENT_VER = 2.4
-COMPAT_VER = 2.0
+LIB_OBJS = $(LIB_SRCS:.c=.o)
+LIB_DOBJS = $(LIB_SRCS:.c=.lo)
 
 LIB_A = libslink.a
-LIB_SO = libslink.so.$(CURRENT_VER)
-LIB_SO_ALIAS = libslink.so
-LIB_DYN = libslink.$(CURRENT_VER).dylib
+LIB_SO_FILENAME = libslink.so
+LIB_SO_ALIAS = $(LIB_SO_FILENAME).$(MAJOR_VER)
+LIB_SO = $(LIB_SO_FILENAME).$(CURRENT_VER)
 LIB_DYN_ALIAS = libslink.dylib
+LIB_DYN = libslink.$(CURRENT_VER).dylib
 
 all: static
 
@@ -29,34 +31,41 @@ shared: $(LIB_SO)
 
 dynamic: $(LIB_DYN)
 
+# Build static library
 $(LIB_A): $(LIB_OBJS)
-	ar -rcs $(LIB_A) $(LIB_OBJS)
+	rm -f $(LIB_A)
+	ar -crs $(LIB_A) $(LIB_OBJS)
 
-$(LIB_SO): $(LIB_OBJS)
-	$(CC) -shared -Wl,-soname -Wl,$(LIB_SO_ALIAS) -o $(LIB_SO) $(LIB_OBJS)
+# Build shared library using GCC-style options
+$(LIB_SO): $(LIB_DOBJS)
+	rm -f $(LIB_SO) $(LIB_SO_ALIAS) $(LIB_SO_FILENAME)
+	$(CC) $(CFLAGS) -shared -Wl,-soname -Wl,$(LIB_SO_ALIAS) -o $(LIB_SO) $(LIB_DOBJS)
 	ln -s $(LIB_SO) $(LIB_SO_ALIAS)
+	ln -s $(LIB_SO) $(LIB_SO_FILENAME)
 
-$(LIB_DYN): $(LIB_OBJS)
-	$(CC) -dynamiclib -compatibility_version $(COMPAT_VER) -current_version $(CURRENT_VER) -install_name $(LIB_DYN_ALIAS) -o $(LIB_DYN) $(LIB_OBJS)
-	ln -s $(LIB_DYN) $(LIB_DYN_ALIAS)
-
-cc:
-	@$(MAKE) "CC=$(CC)" "CFLAGS=$(CFLAGS)"
-
-gcc:
-	@$(MAKE) "CC=$(GCC)" "CFLAGS=$(GCCFLAGS)"
-
-debug:
-	$(MAKE) "CC=$(CC)" "CFLAGS=-g $(CFLAGS)"
-
-gccdebug:
-	$(MAKE) "CC=$(GCC)" "CFLAGS=-g $(GCCFLAGS)"
+# Build dynamic library (usually for Mac OSX)
+$(LIB_DYN): $(LIB_DOBJS)
+	rm -f $(LIB_DYN) $(LIB_DYN_ALIAS)
+	$(CC) $(CFLAGS) -dynamiclib -compatibility_version $(COMPAT_VER) -current_version $(CURRENT_VER) -install_name $(LIB_DYN_ALIAS) -o $(LIB_DYN) $(LIB_DOBJS)
+	ln -sf $(LIB_DYN) $(LIB_DYN_ALIAS)
 
 clean:
-	rm -f $(LIB_OBJS) $(LIB_A) $(LIB_SO) $(LIB_SO_ALIAS) $(LIB_DYN) $(LIB_DYN_ALIAS)
+	rm -f $(LIB_OBJS) $(LIB_DOBJS) $(LIB_A) $(LIB_SO) $(LIB_SO_ALIAS) \
+	      $(LIB_SO_FILENAME) $(LIB_DYN) $(LIB_DYN_ALIAS)
 
 install:
 	@echo
-	@echo "No install method, copy the library, header file, and"
+	@echo "No install method, copy the library, header files, and"
 	@echo "documentation to the preferred install location"
 	@echo
+
+.SUFFIXES: .c .o .lo
+
+# Standard object building
+.c.o:
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Standard object building for dynamic library components using -fPIC
+.c.lo:
+	$(CC) $(CFLAGS) -fPIC -c $< -o $@
+

--- a/bin/rt/slink2orb/libslink/Makefile.win
+++ b/bin/rt/slink2orb/libslink/Makefile.win
@@ -1,13 +1,11 @@
 #
-#
-# Nmake File For libslink - MS Visual C++ version
+# Nmake file For libslink - MS Visual C/C++
 # Use 'nmake -f Makefile.win'
 
 NODEBUG=1
 
-!include <ntwin32.mak>
-
 INCS = /I.
+OPTS = -D_CRT_SECURE_NO_WARNINGS
 LIB = libslink.lib
 DLL = libslink.dll
 
@@ -33,8 +31,7 @@ dll: $(OBJS)
 	link.exe /dll /nologo /out:$(DLL) $(OBJS)
 
 .c.obj:
-   $(cc) /nologo $(cflags) $(cdebug) $(cvarsmt) $(tflags) $(INCS) $<
-
+   $(CC) /nologo $(CFLAGS) $(INCS) $(OPTS) /c $< 
 
 # Clean-up directives
 clean:

--- a/bin/rt/slink2orb/libslink/README
+++ b/bin/rt/slink2orb/libslink/README
@@ -6,39 +6,13 @@ for libslink, the SeedLink client library.  For further information
 regarding the library interface and usage see the documentation in the
 'doc' directory, including a Users Guide and man pages.
 
-Installation instructions for libslink: the SeedLink client library.
+The library should work in Linux, BSD (and derivatives like macOS),
+Solaris and MS-Windows environments.
 
--- Building --
-
-Linux/Unix: The easiest way to compile the library is to simply run
-'make'.  The included Makefile should work for most Unix-like
-environments; a special target of 'gcc' will explicitly use gcc with
-'-02' optimization and more warnings.  By default a statically linked
-version of the library is built 'libslink.a'.  Using gcc it is
-possible to build a shared library with 'make shared'.
-
-Mac OSX (Darwin): A static library can be compiled using the above
-Linux/Unix instructions, just run 'make'.  A dynamic library can be
-built with 'make dynamic'.
-
-Windows: On a WIN32 platform the library can be compiled by using the
-Nmake compatible Makefile.win (e.g. 'nmake -f Makefile.win') or Open
-Watcom's Wmake with Makefile.wat (e.g. 'wmake -f Makefile.wat'). The
-default target is a static library 'libslink.lib'.  The library has
-been tested with Microsoft Visual Studio 6 and Open Watcom 1.1.
-
-For non-WIN32 platforms the POSIX nanosleep() function is used.  This
-function may not be implemented on older Solaris or Linux platforms.
-It is known to be available under Solaris 8 or later and recent
-versions of Glibc2.
-
--- Installing --
-
-For installation into the system development environment simply copy
-the library (libslink.a, libslink.so* and/or libslink.*.dylib) into a
-system library directory and copy the associated header file
-(libslink.h) into a system include directory.  Otherwise the library
-and include file can be used directly from the build directory.
+For installation instructions see the INSTALL file.  For further
+information regarding the library interface see the documentation in
+the 'doc' directory.  For example uses of libslink see the source code
+in the 'examples' directory.
 
 -- Extras --
 
@@ -55,6 +29,33 @@ condition that each connection descriptor (SLCD) is handled by a
 single thread.  Thread independent logging schemes are possible.
 Under WIN32 the library is not thread-safe.
 
+-- Licensing --
+
+Copyright (C) 2016 Chad Trabant, IRIS Data Management Center
+
+This library is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 3 of the
+License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License (GNU-LGPL) for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this software.
+If not, see <https://www.gnu.org/licenses/>.
+
+-- Acknowlegements --
+
+Numerous improvements have been incorporated based on feedback and
+patches submitted by others.  Individual acknowlegements are included
+in the ChangeLog.
+
+Initial development at the ORFEUS Data Center/EC MEREDIAN Project
+Continuing maintenance at the IRIS Data Management Center
+
 -- Pronunciation --
 
 lib = 'l' + [eye] + 'b'  (as in library, long 'i')
@@ -62,24 +63,3 @@ s = [es]   (like the beginning of 'esta' in como esta?)
 link = link   (rhymes with the color pink)
 
 all together: 'l' [eye] 'b' [es] link
-
--- Licensing --
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Library General Public License
-as published by the Free Software Foundation; either version 2 of
-the License, or (at your option) any later version.
-
-This library is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Library General Public License (GNU-LGPL) for more details.  The
-GNU-LGPL and further information can be found here:
-http://www.gnu.org/
-
--- Author --
-
-Chad Trabant
-Initial development at the ORFEUS Data Center/EC MEREDIAN Project
-Continuing maintenance at the IRIS Data Management Center
-

--- a/bin/rt/slink2orb/libslink/config.c
+++ b/bin/rt/slink2orb/libslink/config.c
@@ -9,17 +9,16 @@
  * modified: 2013.305
  ***************************************************************************/
 
-#include <stdio.h>
 #include <errno.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "libslink.h"
 
-
 /***************************************************************************
  * sl_read_streamlist:
  *
- * Read a list of streams and selectors from a file and add them to the 
+ * Read a list of streams and selectors from a file and add them to the
  * stream chain for configuring a multi-station connection.
  *
  * If 'defselect' is not NULL or 0 it will be used as the default selectors
@@ -33,13 +32,13 @@
  * GE ISP  BH?.D
  * NL HGN
  * MN AQU  BH?  HH?
- * -------- 
+ * --------
  *
  * Returns the number of streams configured or -1 on error.
  ***************************************************************************/
 int
-sl_read_streamlist (SLCD * slconn, const char * streamfile,
-		    const char * defselect)
+sl_read_streamlist (SLCD *slconn, const char *streamfile,
+                    const char *defselect)
 {
   char net[3];
   char sta[6];
@@ -49,79 +48,77 @@ sl_read_streamlist (SLCD * slconn, const char * streamfile,
   int fields;
   int count;
   int stacount;
-  int addret;
-  
-  net[0] = '\0';
-  sta[0] = '\0';
+
+  net[0]       = '\0';
+  sta[0]       = '\0';
   selectors[0] = '\0';
-  
+
   /* Open the stream list file */
-  if ( (streamfd = slp_openfile (streamfile, 'r')) < 0 )
+  if ((streamfd = slp_openfile (streamfile, 'r')) < 0)
+  {
+    if (errno == ENOENT)
     {
-      if (errno == ENOENT)
-	{
-	  sl_log_r (slconn, 2, 0, "could not find stream list file: %s\n", streamfile);
-	  return -1;
-	}
-      else
-	{
-	  sl_log_r (slconn, 2, 0, "opening stream list file, %s\n", strerror (errno));
-	  return -1;
-	}
-    }
-  
-  sl_log_r (slconn, 1, 1, "Reading stream list from %s\n", streamfile);
-  
-  count = 1;
-  stacount = 0;
-  
-  while ( (sl_readline (streamfd, line, sizeof(line))) >= 0 )
-    {
-      fields = sscanf (line, "%2s %5s %99[a-zA-Z0-9!?. ]\n",
-		       net, sta, selectors);
-      
-      /* Ignore blank or comment lines */
-      if ( fields < 0 || net[0] == '#' || net[0] == '*' )
-	continue;
-
-      if ( fields < 2 )
-	{
-	  sl_log_r (slconn, 2, 0, "cannot parse line %d of stream list\n", count);
-	}
-      
-      /* Add this stream to the stream chain */
-      if ( fields == 3 )
-	{
-	  sl_addstream (slconn, net, sta, selectors, -1, NULL);
-	  stacount++;
-	}
-      else
-	{
-	  addret = sl_addstream (slconn, net, sta, defselect, -1, NULL);
-	  stacount++;
-	}
-      
-	count++;
-    }
-  
-  if ( stacount == 0 )
-    {
-      sl_log_r (slconn, 2, 0, "no streams defined in %s\n", streamfile);
-    }
-  else if ( stacount > 0 )
-    {
-      sl_log_r (slconn, 1, 2, "Read %d streams from %s\n", stacount, streamfile);
-    }
-
-  if ( close (streamfd) )
-    {
-      sl_log_r (slconn, 2, 0, "closing stream list file, %s\n", strerror (errno));
+      sl_log_r (slconn, 2, 0, "could not find stream list file: %s\n", streamfile);
       return -1;
     }
-  
-  return count;
-}  /* End of sl_read_streamlist() */
+    else
+    {
+      sl_log_r (slconn, 2, 0, "opening stream list file, %s\n", strerror (errno));
+      return -1;
+    }
+  }
 
+  sl_log_r (slconn, 1, 1, "Reading stream list from %s\n", streamfile);
+
+  count    = 1;
+  stacount = 0;
+
+  while ((sl_readline (streamfd, line, sizeof (line))) >= 0)
+  {
+    fields = sscanf (line, "%2s %5s %99[a-zA-Z0-9!?. ]\n",
+                     net, sta, selectors);
+
+    /* Ignore blank or comment lines */
+    if (fields < 0 || net[0] == '#' || net[0] == '*')
+      continue;
+
+    if (fields < 2)
+    {
+      sl_log_r (slconn, 2, 0, "cannot parse line %d of stream list\n", count);
+    }
+
+    /* Add this stream to the stream chain */
+    if (fields == 3)
+    {
+      sl_addstream (slconn, net, sta, selectors, -1, NULL);
+      stacount++;
+    }
+    else
+    {
+      sl_addstream (slconn, net, sta, defselect, -1, NULL);
+      stacount++;
+    }
+
+    count++;
+  }
+
+  if (stacount == 0)
+  {
+    sl_log_r (slconn, 2, 0, "no streams defined in %s\n", streamfile);
+  }
+  else if (stacount > 0)
+  {
+    sl_log_r (slconn, 1, 2, "Read %d streams from %s\n", stacount, streamfile);
+  }
+
+  if (close (streamfd))
+  {
+    sl_log_r (slconn, 2, 0, "closing stream list file, %s\n", strerror (errno));
+    return -1;
+  }
+
+  return count;
+} /* End of sl_read_streamlist() */
 
 /***************************************************************************
  * sl_parse_streamlist:
@@ -134,12 +131,12 @@ sl_read_streamlist (SLCD * slconn, const char * streamfile,
  *
  * For example:
  * "IU_KONO:BHE BHN,GE_WLF,MN_AQU:HH?.D"
- * 
+ *
  * Returns the number of streams configured or -1 on error.
  ***************************************************************************/
 int
-sl_parse_streamlist (SLCD * slconn, const char * streamlist,
-		     const char * defselect)
+sl_parse_streamlist (SLCD *slconn, const char *streamlist,
+                     const char *defselect)
 {
   int count = 0;
   int fields;
@@ -148,108 +145,108 @@ sl_parse_streamlist (SLCD * slconn, const char * streamlist,
   char *net;
   char *sta;
 
-  SLstrlist *ringlist   = NULL;       /* split streamlist on ',' */
-  SLstrlist *reqlist    = NULL;       /* split ringlist on ':' */
-  SLstrlist *netstalist = NULL;       /* split reqlist[0] on "_" */
+  SLstrlist *ringlist   = NULL; /* split streamlist on ',' */
+  SLstrlist *reqlist    = NULL; /* split ringlist on ':' */
+  SLstrlist *netstalist = NULL; /* split reqlist[0] on "_" */
 
-  SLstrlist *ringptr    = NULL;
-  SLstrlist *reqptr     = NULL;
-  SLstrlist *netstaptr  = NULL;
+  SLstrlist *ringptr   = NULL;
+  SLstrlist *reqptr    = NULL;
+  SLstrlist *netstaptr = NULL;
 
   /* Parse the streams and selectors */
   sl_strparse (streamlist, ",", &ringlist);
   ringptr = ringlist;
 
   while (ringptr != 0)
+  {
+    net       = NULL;
+    sta       = NULL;
+    staselect = NULL;
+
+    fields = sl_strparse (ringptr->element, ":", &reqlist);
+    reqptr = reqlist;
+
+    /* Fill in the NET and STA fields */
+    if (sl_strparse (reqptr->element, "_", &netstalist) != 2)
     {
-      net = NULL;
-      sta = NULL;
-      staselect = NULL;
-      
-      fields = sl_strparse (ringptr->element, ":", &reqlist);
-      reqptr = reqlist;
+      sl_log_r (slconn, 2, 0, "not in NET_STA format: %s\n", reqptr->element);
+      count = -1;
+    }
+    else
+    {
+      /* Point to the first element, should be a network code */
+      netstaptr = netstalist;
+      if (strlen (netstaptr->element) == 0)
+      {
+        sl_log_r (slconn, 2, 0, "not in NET_STA format: %s\n",
+                  reqptr->element);
+        count = -1;
+      }
+      net = netstaptr->element;
 
-      /* Fill in the NET and STA fields */
-      if (sl_strparse (reqptr->element, "_", &netstalist) != 2)
-	{
-	  sl_log_r (slconn, 2, 0, "not in NET_STA format: %s\n", reqptr->element);
-	  count = -1;
-	}
-      else
-	{
-	  /* Point to the first element, should be a network code */
-	  netstaptr = netstalist;
-	  if (strlen (netstaptr->element) == 0)
-	    {
-	      sl_log_r (slconn, 2, 0, "not in NET_STA format: %s\n",
-		      reqptr->element);
-	      count = -1;
-	    }
-	  net = netstaptr->element;
-	  
-	  /* Point to the second element, should be a station code */
-	  netstaptr = netstaptr->next;
-	  if (strlen (netstaptr->element) == 0)
-	    {
-	      sl_log_r (slconn, 2, 0, "not in NET_STA format: %s\n",
-		      reqptr->element);
-	      count = -1;
-	    }
-	  sta = netstaptr->element;
-	}
-
-      if (fields > 1)
-	{                   /* Selectors were included */
-	  /* Point to the second element of reqptr, should be selectors */
-	  reqptr = reqptr->next;
-	  if (strlen (reqptr->element) == 0)
-	    {
-	      sl_log_r (slconn, 2, 0, "empty selector: %s\n", reqptr->element);
-	      count = -1;
-	    }
-	  staselect = reqptr->element;
-	}
-      else  /* If no specific selectors, use the default */
-	{
-	  staselect = defselect;
-	}
-      
-      /* Add this to the stream chain */
-      if ( count != -1 )
-        {
-          sl_addstream(slconn, net, sta, staselect, -1, 0);
-      	  count++;
-	}
-
-      /* Free the netstalist (the 'NET_STA' part) */
-      sl_strparse (NULL, NULL, &netstalist);
-      
-      /* Free the reqlist (the 'NET_STA:selector' part) */
-      sl_strparse (NULL, NULL, &reqlist);
-      
-      ringptr = ringptr->next;
+      /* Point to the second element, should be a station code */
+      netstaptr = netstaptr->next;
+      if (strlen (netstaptr->element) == 0)
+      {
+        sl_log_r (slconn, 2, 0, "not in NET_STA format: %s\n",
+                  reqptr->element);
+        count = -1;
+      }
+      sta = netstaptr->element;
     }
 
-  if ( netstalist != NULL )
-    {
-      sl_strparse (NULL, NULL, &netstalist);
+    if (fields > 1)
+    { /* Selectors were included */
+      /* Point to the second element of reqptr, should be selectors */
+      reqptr = reqptr->next;
+      if (strlen (reqptr->element) == 0)
+      {
+        sl_log_r (slconn, 2, 0, "empty selector: %s\n", reqptr->element);
+        count = -1;
+      }
+      staselect = reqptr->element;
     }
-  if ( reqlist != NULL )
+    else /* If no specific selectors, use the default */
     {
-      sl_strparse (NULL, NULL, &reqlist);
+      staselect = defselect;
     }
-  
-  if ( count == 0 )
+
+    /* Add this to the stream chain */
+    if (count != -1)
     {
-      sl_log_r (slconn, 2, 0, "no streams defined in stream list\n");
+      sl_addstream (slconn, net, sta, staselect, -1, 0);
+      count++;
     }
-  else if ( count > 0 )
-    {
-      sl_log_r (slconn, 1, 2, "Parsed %d streams from stream list\n", count);
-    }
+
+    /* Free the netstalist (the 'NET_STA' part) */
+    sl_strparse (NULL, NULL, &netstalist);
+
+    /* Free the reqlist (the 'NET_STA:selector' part) */
+    sl_strparse (NULL, NULL, &reqlist);
+
+    ringptr = ringptr->next;
+  }
+
+  if (netstalist != NULL)
+  {
+    sl_strparse (NULL, NULL, &netstalist);
+  }
+  if (reqlist != NULL)
+  {
+    sl_strparse (NULL, NULL, &reqlist);
+  }
+
+  if (count == 0)
+  {
+    sl_log_r (slconn, 2, 0, "no streams defined in stream list\n");
+  }
+  else if (count > 0)
+  {
+    sl_log_r (slconn, 1, 2, "Parsed %d streams from stream list\n", count);
+  }
 
   /* Free the ring list */
   sl_strparse (NULL, NULL, &ringlist);
-  
+
   return count;
-}  /* End of sl_parse_streamlist() */
+} /* End of sl_parse_streamlist() */

--- a/bin/rt/slink2orb/libslink/doc/sl_msr_new.3
+++ b/bin/rt/slink2orb/libslink/doc/sl_msr_new.3
@@ -1,4 +1,4 @@
-.TH MSR_NEW 3 2006/12/10
+.TH MSR_NEW 3 2016/10/14
 .SH NAME
 Utility routines for parsing, printing, etc. of Mini-SEED records
 
@@ -11,7 +11,11 @@ Utility routines for parsing, printing, etc. of Mini-SEED records
 .sp
 .BI "SLMSrecord * \fBsl_msr_parse\fP (SLlog *" log ", char *" msrecord ", SLMSrecord **" msr ",
 .BI "                           int " blktflag " , int " unpackflag );
-.BI "int        \fBsl_msr_print\fP (SLlog *" log ", SLMSrecord *" msr ", int " details ");
+.sp
+.BI "int        \fBsl_msr_print\fP (SLlog *" log ", SLMSrecord *" msr ", int " details ");"
+.sp
+.BI "int        \fBsl_msr_srcname\fP (SLMSrecord *" msr ", char *" srcname ",
+.BI "                           int8_t " quality );
 .sp
 .BI "int        \fBsl_msr_dsamprate\fP (SLMSrecord *" msr ", double *" samprate );
 .BI "double     \fBsl_msr_dnomsamprate\fP (SLMSrecord *" msr );
@@ -80,6 +84,12 @@ in an associated SLCD.  If \fIlog\fP is NULL global logging parameters
 will be used.  If the \fIdetails\fP flag is greater than zero detailed
 information (values in the fixed header and following blockettes) is
 printed.  Otherwise only a single line for each packet is printed.
+
+\fBsl_msr_srcname\fP will generate a source name string of the format
+"Net_Sta_Loc_Chan[_Qual]" for the given SLMSrecord.  The data quality
+indicator will be added to the source name if the \fIquality\fP flag
+is true.  The supplied \fIsrcname\fP buffer must have enough room to
+hold the result.
 
 \fBsl_msr_dsamprate\fP, \fBsl_msr_dnomsamprate\fP and
 \fBsl_msr_depochstime\fP are helper functions for common, mundane

--- a/bin/rt/slink2orb/libslink/doc/sl_msr_srcname.3
+++ b/bin/rt/slink2orb/libslink/doc/sl_msr_srcname.3
@@ -1,0 +1,1 @@
+sl_msr_new.3

--- a/bin/rt/slink2orb/libslink/example/Makefile
+++ b/bin/rt/slink2orb/libslink/example/Makefile
@@ -14,6 +14,10 @@ CFLAGS += -I..
 LDFLAGS = -L..
 LDLIBS = -lslink
 
+# For Windows w/ Unix-like build environments uncomment the following line
+# This is needed for MinGW but not for Cygwin
+#LDLIBS = -lslink -lws2_32
+
 # For SunOS/Solaris uncomment the following line
 #LDLIBS = -lslink -lsocket -lnsl -lrt
 

--- a/bin/rt/slink2orb/libslink/example/Makefile.win
+++ b/bin/rt/slink2orb/libslink/example/Makefile.win
@@ -1,19 +1,13 @@
 #
-#
 # Nmake file for libslink example client - Windows version
 # Use 'nmake -f Makefile.win'
 
-NODEBUG=1
-
-!include <ntwin32.mak>
-
 INCS = /I..
+OPTS = -D_CRT_SECURE_NO_WARNINGS
 LIBS = ../libslink.lib ws2_32.lib
 BIN = slclient.exe
 
 OBJS =	slclient.obj
-
-cflags = $(cflags) -DWIN32
 
 all: slclient
 
@@ -21,7 +15,7 @@ slclient: $(OBJS)
 	link.exe /nologo /out:$(BIN) $(LIBS) $(OBJS)
 
 .c.obj:
-   $(cc) /nologo $(cflags) $(cdebug) $(cvarsmt) $(tflags) $(INCS) $<
+	$(CC) /nologo $(CFLAGS) $(INCS) $(OPTS) /c $<
 
 # Clean-up directives
 clean:

--- a/bin/rt/slink2orb/libslink/genutils.c
+++ b/bin/rt/slink2orb/libslink/genutils.c
@@ -16,7 +16,6 @@
 
 #include "libslink.h"
 
-
 /***************************************************************************
  * sl_dtime:
  *
@@ -27,9 +26,8 @@ double
 sl_dtime (void)
 {
   /* Now just a shell for the portable version */
-  return slp_dtime();
-}  /* End of sl_dtime() */
-
+  return slp_dtime ();
+} /* End of sl_dtime() */
 
 /***************************************************************************
  * sl_doy2md:
@@ -39,47 +37,46 @@ sl_dtime (void)
  * Returns 0 on success and -1 on error.
  ***************************************************************************/
 int
-sl_doy2md(int year, int jday, int *month, int *mday)
+sl_doy2md (int year, int jday, int *month, int *mday)
 {
   int idx;
   int leap;
   int days[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-  
+
   /* Sanity check for the supplied year */
-  if ( year < 1900 || year > 2100 )
-    {
-      sl_log_r (NULL, 2, 0, "sl_doy2md(): year (%d) is out of range\n", year);
-      return -1;
-    }
-    
+  if (year < 1900 || year > 2100)
+  {
+    sl_log_r (NULL, 2, 0, "sl_doy2md(): year (%d) is out of range\n", year);
+    return -1;
+  }
+
   /* Test for leap year */
-  leap = ( ((year%4 == 0) && (year%100 != 0)) || (year%400 == 0) ) ? 1 : 0;
+  leap = (((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0)) ? 1 : 0;
 
   /* Add a day to February if leap year */
-  if ( leap )
+  if (leap)
     days[1]++;
 
-  if (jday > 365+leap || jday <= 0)
-    {
-      sl_log_r (NULL, 2, 0, "sl_doy2md(): day-of-year (%d) is out of range\n", jday);
-      return -1;
-    }
-    
-  for ( idx=0; idx < 12; idx++ )
-    {
-      jday -= days[idx];
+  if (jday > 365 + leap || jday <= 0)
+  {
+    sl_log_r (NULL, 2, 0, "sl_doy2md(): day-of-year (%d) is out of range\n", jday);
+    return -1;
+  }
 
-      if ( jday <= 0 )
-	{
-	  *month = idx + 1;
-	  *mday = days[idx] + jday;
-	  break;
-	}
+  for (idx = 0; idx < 12; idx++)
+  {
+    jday -= days[idx];
+
+    if (jday <= 0)
+    {
+      *month = idx + 1;
+      *mday  = days[idx] + jday;
+      break;
     }
+  }
 
   return 0;
-}  /* End of sl_doy2md() */
-
+} /* End of sl_doy2md() */
 
 /***************************************************************************
  * sl_checkversion:
@@ -92,22 +89,21 @@ sl_doy2md(int year, int jday, int *month, int *mday)
  * -1 = version is less than value specified
  ***************************************************************************/
 int
-sl_checkversion (const SLCD * slconn, float version)
+sl_checkversion (const SLCD *slconn, float version)
 {
   if (slconn->protocol_ver == 0.0)
-    {
-      return 0;
-    }
+  {
+    return 0;
+  }
   else if (slconn->protocol_ver >= version)
-    {
-      return 1;
-    }
+  {
+    return 1;
+  }
   else
-    {
-      return -1;
-    }
-}  /* End of sl_checkversion() */
-
+  {
+    return -1;
+  }
+} /* End of sl_checkversion() */
 
 /***************************************************************************
  * sl_checkslcd:
@@ -117,19 +113,18 @@ sl_checkversion (const SLCD * slconn, float version)
  * Returns 0 if pass and -1 if problems were identified.
  ***************************************************************************/
 int
-sl_checkslcd (const SLCD * slconn)
+sl_checkslcd (const SLCD *slconn)
 {
   int retval = 0;
 
   if (slconn->streams == NULL && slconn->info == NULL)
-    {
-      sl_log_r (slconn, 2, 0, "sl_checkslconn(): stream chain AND info type are empty\n");
-      retval = -1;
-    }
+  {
+    sl_log_r (slconn, 2, 0, "sl_checkslconn(): stream chain AND info type are empty\n");
+    retval = -1;
+  }
 
   return retval;
-}  /* End of sl_checkslconn() */
-
+} /* End of sl_checkslconn() */
 
 /***************************************************************************
  * sl_readline:
@@ -146,30 +141,30 @@ int
 sl_readline (int fd, char *buffer, int buflen)
 {
   int nread = 0;
-  
-  if ( ! buffer )
+
+  if (!buffer)
     return -1;
-  
+
   /* Read data from stream until newline character or max characters */
-  while ( nread < (buflen-1) )
+  while (nread < (buflen - 1))
+  {
+    /* Read a single character from the stream */
+    if (read (fd, buffer + nread, 1) != 1)
     {
-      /* Read a single character from the stream */
-      if ( read (fd, buffer+nread, 1) != 1 )
-	{
-	  return -1;
-	}
-      
-      /* Trap door for newline character */
-      if ( buffer[nread] == '\n' )
-	{
-	  break;
-	}
-      
-      nread++;
+      return -1;
     }
-  
+
+    /* Trap door for newline character */
+    if (buffer[nread] == '\n')
+    {
+      break;
+    }
+
+    nread++;
+  }
+
   /* Terminate string in buffer */
   buffer[nread] = '\0';
-  
+
   return nread;
-}  /* End of sl_readline() */
+} /* End of sl_readline() */

--- a/bin/rt/slink2orb/libslink/globmatch.c
+++ b/bin/rt/slink2orb/libslink/globmatch.c
@@ -37,17 +37,15 @@
  * Revision 1.2  94/12/11  10:38:15  oz
  * charset code fixed. it is now robust and interprets all
  * variations of charset [i think] correctly, including [z-a] etc.
- * 
+ *
  * Revision 1.1  94/12/08  12:45:23  oz
  * Initial revision
  */
 
-
 #include "globmatch.h"
 
-#define SL_GLOBMATCH_TRUE    1
-#define SL_GLOBMATCH_FALSE   0
-
+#define SL_GLOBMATCH_TRUE 1
+#define SL_GLOBMATCH_FALSE 0
 
 /***********************************************************************
  * sl_globmatch:
@@ -62,113 +60,113 @@ sl_globmatch (char *string, char *pattern)
   int negate;
   int match;
   int c;
-  
-  while ( *pattern )
+
+  while (*pattern)
+  {
+    if (!*string && *pattern != '*')
+      return SL_GLOBMATCH_FALSE;
+
+    switch (c = *pattern++)
     {
-      if ( !*string && *pattern != '*' )
-	return SL_GLOBMATCH_FALSE;
-      
-      switch ( c = *pattern++ )
-	{
-	  
-	case '*':
-	  while ( *pattern == '*' )
-	    pattern++;
-	  
-	  if ( !*pattern )
-	    return SL_GLOBMATCH_TRUE;
-	  
-	  if ( *pattern != '?' && *pattern != '[' && *pattern != '\\' )
-	    while ( *string && *pattern != *string )
-	      string++;
-	  
-	  while ( *string )
-	    {
-	      if ( sl_globmatch(string, pattern) )
-		return SL_GLOBMATCH_TRUE;
-	      string++;
-	    }
-	  return SL_GLOBMATCH_FALSE;
-	  
-	case '?':
-	  if ( *string )
-	    break;
-	  return SL_GLOBMATCH_FALSE;
-	  
-	  /* set specification is inclusive, that is [a-z] is a, z and
+
+    case '*':
+      while (*pattern == '*')
+        pattern++;
+
+      if (!*pattern)
+        return SL_GLOBMATCH_TRUE;
+
+      if (*pattern != '?' && *pattern != '[' && *pattern != '\\')
+        while (*string && *pattern != *string)
+          string++;
+
+      while (*string)
+      {
+        if (sl_globmatch (string, pattern))
+          return SL_GLOBMATCH_TRUE;
+        string++;
+      }
+      return SL_GLOBMATCH_FALSE;
+
+    case '?':
+      if (*string)
+        break;
+      return SL_GLOBMATCH_FALSE;
+
+    /* set specification is inclusive, that is [a-z] is a, z and
 	   * everything in between. this means [z-a] may be interpreted
 	   * as a set that contains z, a and nothing in between.
 	   */
-	case '[':
-	  if ( *pattern != SL_GLOBMATCH_NEGATE )
-	    negate = SL_GLOBMATCH_FALSE;
-	  else
-	    {
-	      negate = SL_GLOBMATCH_TRUE;
-	      pattern++;
-	    }
-	  
-	  match = SL_GLOBMATCH_FALSE;
-	  
-	  while ( !match && (c = *pattern++) )
-	    {
-	      if ( !*pattern )
-		return SL_GLOBMATCH_FALSE;
-	      
-	      if ( *pattern == '-' ) 	/* c-c */
-		{
-		  if ( !*++pattern )
-		    return SL_GLOBMATCH_FALSE;
-		  if ( *pattern != ']' )
-		    {
-		      if ( *string == c || *string == *pattern ||
-			   ( *string > c && *string < *pattern ) )
-			match = SL_GLOBMATCH_TRUE;
-		    }
-		  else
-		    {		/* c-] */
-		      if ( *string >= c )
-			match = SL_GLOBMATCH_TRUE;
-		      break;
-		    }
-		}
-	      else			/* cc or c] */
-		{
-		  if ( c == *string )
-		    match = SL_GLOBMATCH_TRUE;
-		  if ( *pattern != ']' )
-		    {
-		      if ( *pattern == *string )
-			match = SL_GLOBMATCH_TRUE;
-		    }
-		  else
-		    break;
-		}
-	    } 
-	  
-	  if ( negate == match )
-	    return SL_GLOBMATCH_FALSE;
-	  
-	  /*
+    case '[':
+      if (*pattern != SL_GLOBMATCH_NEGATE)
+        negate = SL_GLOBMATCH_FALSE;
+      else
+      {
+        negate = SL_GLOBMATCH_TRUE;
+        pattern++;
+      }
+
+      match = SL_GLOBMATCH_FALSE;
+
+      while (!match && (c = *pattern++))
+      {
+        if (!*pattern)
+          return SL_GLOBMATCH_FALSE;
+
+        if (*pattern == '-') /* c-c */
+        {
+          if (!*++pattern)
+            return SL_GLOBMATCH_FALSE;
+          if (*pattern != ']')
+          {
+            if (*string == c || *string == *pattern ||
+                (*string > c && *string < *pattern))
+              match = SL_GLOBMATCH_TRUE;
+          }
+          else
+          { /* c-] */
+            if (*string >= c)
+              match = SL_GLOBMATCH_TRUE;
+            break;
+          }
+        }
+        else /* cc or c] */
+        {
+          if (c == *string)
+            match = SL_GLOBMATCH_TRUE;
+          if (*pattern != ']')
+          {
+            if (*pattern == *string)
+              match = SL_GLOBMATCH_TRUE;
+          }
+          else
+            break;
+        }
+      }
+
+      if (negate == match)
+        return SL_GLOBMATCH_FALSE;
+
+      /*
 	   * if there is a match, skip past the charset and continue on
 	   */
-	  while ( *pattern && *pattern != ']' )
-	    pattern++;
-	  if ( !*pattern++ )	/* oops! */
-	    return SL_GLOBMATCH_FALSE;
-	  break;
-	  
-	case '\\':
-	  if ( *pattern )
-	    c = *pattern++;
-	default:
-	  if ( c != *string )
-	    return SL_GLOBMATCH_FALSE;
-	  break;
-	}
-      
-      string++;
+      while (*pattern && *pattern != ']')
+        pattern++;
+      if (!*pattern++) /* oops! */
+        return SL_GLOBMATCH_FALSE;
+      break;
+
+    case '\\':
+      if (*pattern)
+        c = *pattern++;
+    default:
+      if (c != *string)
+        return SL_GLOBMATCH_FALSE;
+      break;
     }
-  
+
+    string++;
+  }
+
   return !*string;
 }

--- a/bin/rt/slink2orb/libslink/gswap.c
+++ b/bin/rt/slink2orb/libslink/gswap.c
@@ -28,125 +28,117 @@
 /* Swap routines that work on any (aligned or not) quantities */
 
 void
-sl_gswap2 ( void *data2 )
+sl_gswap2 (void *data2)
 {
   uint8_t temp;
-  
-  union
-  {
-    uint8_t  c[2];
+
+  union {
+    uint8_t c[2];
   } dat;
-  
-  memcpy( &dat, data2, sizeof(dat) );
+
+  memcpy (&dat, data2, sizeof (dat));
   temp     = dat.c[0];
   dat.c[0] = dat.c[1];
   dat.c[1] = temp;
-  memcpy( data2, &dat, sizeof(dat) );
+  memcpy (data2, &dat, sizeof (dat));
 }
 
-
 void
-sl_gswap3 ( void *data3 )
+sl_gswap3 (void *data3)
 {
   uint8_t temp;
-  
-  union
-  {
-    uint8_t  c[3];
+
+  union {
+    uint8_t c[3];
   } dat;
-  
-  memcpy( &dat, data3, sizeof(dat) );
+
+  memcpy (&dat, data3, sizeof (dat));
   temp     = dat.c[0];
   dat.c[0] = dat.c[2];
   dat.c[2] = temp;
-  memcpy( data3, &dat, sizeof(dat) );
+  memcpy (data3, &dat, sizeof (dat));
 }
 
-
 void
-sl_gswap4 ( void *data4 )
+sl_gswap4 (void *data4)
 {
   uint8_t temp;
 
   union {
     uint8_t c[4];
   } dat;
-  
-  memcpy( &dat, data4, sizeof(dat) );
+
+  memcpy (&dat, data4, sizeof (dat));
   temp     = dat.c[0];
   dat.c[0] = dat.c[3];
   dat.c[3] = temp;
   temp     = dat.c[1];
   dat.c[1] = dat.c[2];
   dat.c[2] = temp;
-  memcpy( data4, &dat, sizeof(dat) );
+  memcpy (data4, &dat, sizeof (dat));
 }
 
-
 void
-sl_gswap8 ( void *data8 )
+sl_gswap8 (void *data8)
 {
   uint8_t temp;
-  
-  union
-  {
-    uint8_t   c[8];
+
+  union {
+    uint8_t c[8];
   } dat;
-  
-  memcpy( &dat, data8, sizeof(dat) );
+
+  memcpy (&dat, data8, sizeof (dat));
   temp     = dat.c[0];
   dat.c[0] = dat.c[7];
   dat.c[7] = temp;
-  
+
   temp     = dat.c[1];
   dat.c[1] = dat.c[6];
   dat.c[6] = temp;
-  
+
   temp     = dat.c[2];
   dat.c[2] = dat.c[5];
   dat.c[5] = temp;
-  
+
   temp     = dat.c[3];
   dat.c[3] = dat.c[4];
   dat.c[4] = temp;
-  memcpy( data8, &dat, sizeof(dat) );
+  memcpy (data8, &dat, sizeof (dat));
 }
 
 /* Swap routines that work on memory aligned quantities */
 
 void
-sl_gswap2a ( void *data2 )
+sl_gswap2a (void *data2)
 {
   uint16_t *data = data2;
-  
-  *data=(((*data>>8)&0xff) | ((*data&0xff)<<8));
+
+  *data = (((*data >> 8) & 0xff) | ((*data & 0xff) << 8));
 }
 
-
 void
-sl_gswap4a ( void *data4 )
+sl_gswap4a (void *data4)
 {
   uint32_t *data = data4;
-  
-  *data=(((*data>>24)&0xff) | ((*data&0xff)<<24) |
-	 ((*data>>8)&0xff00) | ((*data&0xff00)<<8));
+
+  *data = (((*data >> 24) & 0xff) | ((*data & 0xff) << 24) |
+           ((*data >> 8) & 0xff00) | ((*data & 0xff00) << 8));
 }
 
-
 void
-sl_gswap8a ( void *data8 )
+sl_gswap8a (void *data8)
 {
   uint32_t *data4 = data8;
   uint32_t h0, h1;
-  
+
   h0 = data4[0];
-  h0 = (((h0>>24)&0xff) | ((h0&0xff)<<24) |
-	((h0>>8)&0xff00) | ((h0&0xff00)<<8));
-  
+  h0 = (((h0 >> 24) & 0xff) | ((h0 & 0xff) << 24) |
+        ((h0 >> 8) & 0xff00) | ((h0 & 0xff00) << 8));
+
   h1 = data4[1];
-  h1 = (((h1>>24)&0xff) | ((h1&0xff)<<24) |
-	((h1>>8)&0xff00) | ((h1&0xff00)<<8));
-  
+  h1 = (((h1 >> 24) & 0xff) | ((h1 & 0xff) << 24) |
+        ((h1 >> 8) & 0xff00) | ((h1 & 0xff00) << 8));
+
   data4[0] = h1;
   data4[1] = h0;
 }

--- a/bin/rt/slink2orb/libslink/libslink.h
+++ b/bin/rt/slink2orb/libslink/libslink.h
@@ -1,27 +1,26 @@
 /***************************************************************************
  * libslink.h:
- * 
+ *
  * Interface declarations for the SeedLink library (libslink).
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public License
- * as published by the Free Software Foundation; either version 2 of
- * the License, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License (GNU-LGPL) for more details.  The
- * GNU-LGPL and further information can be found here:
- * http://www.gnu.org/
+ * Lesser General Public License (GNU-LGPL) for more details.
  *
- * Written by Chad Trabant
- *   ORFEUS/EC-Project MEREDIAN
- *   IRIS Data Management Center
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software.
+ * If not, see <https://www.gnu.org/licenses/>.
  *
- * modified: 2012.152
+ * Copyright (C) 2016 Chad Trabant, IRIS Data Management Center
+ *
+ * modified: 2016.288
  ***************************************************************************/
-
 
 #ifndef LIBSLINK_H
 #define LIBSLINK_H 1
@@ -32,8 +31,8 @@ extern "C" {
 
 #include "slplatform.h"
 
-#define LIBSLINK_VERSION "2.4b"
-#define LIBSLINK_RELEASE "2013.305"
+#define LIBSLINK_VERSION "2.6"
+#define LIBSLINK_RELEASE "2016.290"
 
 #define SLRECSIZE           512      /* Default Mini-SEED record size */
 #define MAX_HEADER_SIZE     128      /* Max record header size */
@@ -224,7 +223,7 @@ typedef struct slcd_s
 
   float       protocol_ver;     /* Version of the SeedLink protocol in use */
   const char *info;             /* INFO level to request */
-  int         link;		/* The network socket descriptor */
+  SOCKET      link;		/* The network socket descriptor */
   SLstat     *stat;             /* Persistent state information */
   SLlog      *log;              /* Logging parameters */
 } SLCD;
@@ -255,10 +254,10 @@ extern int   sl_parse_streamlist (SLCD *slconn, const char *streamlist,
 extern int    sl_configlink (SLCD * slconn);
 extern int    sl_send_info (SLCD * slconn, const char * info_level,
 			    int verbose);
-extern int    sl_connect (SLCD * slconn, int sayhello);
+extern SOCKET sl_connect (SLCD * slconn, int sayhello);
 extern int    sl_disconnect (SLCD * slconn);
 extern int    sl_ping (SLCD * slconn, char *serverid, char *site);
-extern int    sl_checksock (int sock, int tosec, int tousec);
+extern int    sl_checksock (SOCKET sock, int tosec, int tousec);
 extern int    sl_senddata (SLCD * slconn, void *buffer, size_t buflen,
 			   const char *ident, void *resp, int resplen);
 extern int    sl_recvdata (SLCD * slconn, void *buffer, size_t maxbytes,
@@ -304,7 +303,7 @@ extern int   sl_savestate (SLCD *slconn, const char *statefile);
 
 typedef struct SLMSrecord_s {
   const char            *msrecord;    /* Pointer to original record */
-  struct sl_fsdh_s       fsdh;        /* Fixed Section of Data Header */ 
+  struct sl_fsdh_s       fsdh;        /* Fixed Section of Data Header */
   struct sl_blkt_100_s  *Blkt100;     /* Blockette 100, if present */
   struct sl_blkt_1000_s *Blkt1000;    /* Blockette 1000, if present */
   struct sl_blkt_1001_s *Blkt1001;    /* Blockette 1001, if present */
@@ -321,6 +320,7 @@ extern SLMSrecord* sl_msr_parse (SLlog * log, const char * msrecord, SLMSrecord 
 extern SLMSrecord* sl_msr_parse_size (SLlog * log, const char * msrecord, SLMSrecord ** msr,
 				      int8_t blktflag, int8_t unpackflag, int slrecsize);
 extern int         sl_msr_print (SLlog * log, SLMSrecord * msr, int details);
+extern char*       sl_msr_srcname (SLMSrecord * msr, char * srcname, int8_t quality);
 extern int         sl_msr_dsamprate (SLMSrecord * msr, double * samprate);
 extern double      sl_msr_dnomsamprate (SLMSrecord * msr);
 extern double      sl_msr_depochstime (SLMSrecord * msr);

--- a/bin/rt/slink2orb/libslink/logging.c
+++ b/bin/rt/slink2orb/libslink/logging.c
@@ -8,22 +8,21 @@
  * modified: 2005.332
  ***************************************************************************/
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <string.h>
 
 #include "libslink.h"
 
-void sl_loginit_main (SLlog * logp, int verbosity,
-		      void (*log_print)(const char*), const char * logprefix,
-		      void (*diag_print)(const char*), const char * errprefix);
+void sl_loginit_main (SLlog *logp, int verbosity,
+                      void (*log_print) (const char *), const char *logprefix,
+                      void (*diag_print) (const char *), const char *errprefix);
 
-int sl_log_main (SLlog * logp, int level, int verb, va_list * varlist);
+int sl_log_main (SLlog *logp, int level, int verb, va_list *varlist);
 
 /* Initialize the global logging parameters */
 SLlog gSLlog = {NULL, NULL, NULL, NULL, 0};
-
 
 /***************************************************************************
  * sl_loginit:
@@ -34,12 +33,11 @@ SLlog gSLlog = {NULL, NULL, NULL, NULL, 0};
  ***************************************************************************/
 void
 sl_loginit (int verbosity,
-	    void (*log_print)(const char*), const char * logprefix,
-	    void (*diag_print)(const char*), const char * errprefix)
+            void (*log_print) (const char *), const char *logprefix,
+            void (*diag_print) (const char *), const char *errprefix)
 {
-  sl_loginit_main(&gSLlog, verbosity, log_print, logprefix, diag_print, errprefix);
-}  /* End of sl_loginit() */
-
+  sl_loginit_main (&gSLlog, verbosity, log_print, logprefix, diag_print, errprefix);
+} /* End of sl_loginit() */
 
 /***************************************************************************
  * sl_loginit_r:
@@ -51,27 +49,26 @@ sl_loginit (int verbosity,
  * See sl_loginit_main() description for usage.
  ***************************************************************************/
 void
-sl_loginit_r (SLCD * slconn, int verbosity,
-	      void (*log_print)(const char*), const char * logprefix,
-	      void (*diag_print)(const char*), const char * errprefix)
+sl_loginit_r (SLCD *slconn, int verbosity,
+              void (*log_print) (const char *), const char *logprefix,
+              void (*diag_print) (const char *), const char *errprefix)
 {
-  if ( ! slconn )
+  if (!slconn)
     return;
 
-  if ( slconn->log == NULL )
-    {
-      slconn->log = (SLlog *) malloc (sizeof(SLlog));
+  if (slconn->log == NULL)
+  {
+    slconn->log = (SLlog *)malloc (sizeof (SLlog));
 
-      slconn->log->log_print = NULL;
-      slconn->log->logprefix = NULL;
-      slconn->log->diag_print = NULL;
-      slconn->log->errprefix = NULL;
-      slconn->log->verbosity = 0;
-    }
+    slconn->log->log_print  = NULL;
+    slconn->log->logprefix  = NULL;
+    slconn->log->diag_print = NULL;
+    slconn->log->errprefix  = NULL;
+    slconn->log->verbosity  = 0;
+  }
 
-  sl_loginit_main(slconn->log, verbosity, log_print, logprefix, diag_print, errprefix);
-}  /* End of sl_loginit_r() */
-
+  sl_loginit_main (slconn->log, verbosity, log_print, logprefix, diag_print, errprefix);
+} /* End of sl_loginit_r() */
 
 /***************************************************************************
  * sl_loginit_rl:
@@ -85,32 +82,31 @@ sl_loginit_r (SLCD * slconn, int verbosity,
  * Returns a pointer to the created/re-initialized SLlog struct.
  ***************************************************************************/
 SLlog *
-sl_loginit_rl (SLlog * log, int verbosity,
-	       void (*log_print)(const char*), const char * logprefix,
-	       void (*diag_print)(const char*), const char * errprefix)
+sl_loginit_rl (SLlog *log, int verbosity,
+               void (*log_print) (const char *), const char *logprefix,
+               void (*diag_print) (const char *), const char *errprefix)
 {
   SLlog *logp;
 
-  if ( log == NULL )
-    {
-      logp = (SLlog *) malloc (sizeof(SLlog));
+  if (log == NULL)
+  {
+    logp = (SLlog *)malloc (sizeof (SLlog));
 
-      logp->log_print = NULL;
-      logp->logprefix = NULL;
-      logp->diag_print = NULL;
-      logp->errprefix = NULL;
-      logp->verbosity = 0;
-    }
+    logp->log_print  = NULL;
+    logp->logprefix  = NULL;
+    logp->diag_print = NULL;
+    logp->errprefix  = NULL;
+    logp->verbosity  = 0;
+  }
   else
-    {
-      logp = log;
-    }
+  {
+    logp = log;
+  }
 
   sl_loginit_main (logp, verbosity, log_print, logprefix, diag_print, errprefix);
 
   return logp;
-}  /* End of sl_loginit_rl() */
-
+} /* End of sl_loginit_rl() */
 
 /***************************************************************************
  * sl_loginit_main:
@@ -135,48 +131,47 @@ sl_loginit_rl (SLlog * log, int verbosity,
  * Example: sl_loginit_main (0, (void*)&printf, NULL, (void*)&printf, "error: ");
  ***************************************************************************/
 void
-sl_loginit_main (SLlog * logp, int verbosity,
-		 void (*log_print)(const char*), const char * logprefix,
-		 void (*diag_print)(const char*), const char * errprefix)
+sl_loginit_main (SLlog *logp, int verbosity,
+                 void (*log_print) (const char *), const char *logprefix,
+                 void (*diag_print) (const char *), const char *errprefix)
 {
-  if ( ! logp )
+  if (!logp)
     return;
 
   logp->verbosity = verbosity;
 
-  if ( log_print )
+  if (log_print)
     logp->log_print = log_print;
 
-  if ( logprefix )
+  if (logprefix)
+  {
+    if (strlen (logprefix) >= MAX_LOG_MSG_LENGTH)
     {
-      if ( strlen(logprefix) >= MAX_LOG_MSG_LENGTH )
-	{
-	  sl_log_rl (logp, 2, 0, "log message prefix is too large\n");
-	}
-      else
-	{
-	  logp->logprefix = logprefix;
-	}
+      sl_log_rl (logp, 2, 0, "log message prefix is too large\n");
     }
+    else
+    {
+      logp->logprefix = logprefix;
+    }
+  }
 
-  if ( diag_print )
+  if (diag_print)
     logp->diag_print = diag_print;
 
-  if ( errprefix )
+  if (errprefix)
+  {
+    if (strlen (errprefix) >= MAX_LOG_MSG_LENGTH)
     {
-      if ( strlen(errprefix) >= MAX_LOG_MSG_LENGTH )
-	{
-	  sl_log_rl (logp, 2, 0, "error message prefix is too large\n");
-	}
-      else
-	{
-	  logp->errprefix = errprefix;
-	}
+      sl_log_rl (logp, 2, 0, "error message prefix is too large\n");
     }
+    else
+    {
+      logp->errprefix = errprefix;
+    }
+  }
 
   return;
-}  /* End of sl_loginit_main() */
-
+} /* End of sl_loginit_main() */
 
 /***************************************************************************
  * sl_log:
@@ -190,7 +185,7 @@ sl_log (int level, int verb, ...)
 {
   int retval;
   va_list varlist;
-  
+
   va_start (varlist, verb);
 
   retval = sl_log_main (&gSLlog, level, verb, &varlist);
@@ -198,8 +193,7 @@ sl_log (int level, int verb, ...)
   va_end (varlist);
 
   return retval;
-}  /* End of sl_log() */
-
+} /* End of sl_log() */
 
 /***************************************************************************
  * sl_log_r:
@@ -211,28 +205,27 @@ sl_log (int level, int verb, ...)
  * See sl_log_main() description for return values.
  ***************************************************************************/
 int
-sl_log_r (const SLCD * slconn, int level, int verb, ...)
+sl_log_r (const SLCD *slconn, int level, int verb, ...)
 {
   int retval;
   va_list varlist;
   SLlog *logp;
 
-  if ( ! slconn )
+  if (!slconn)
     logp = &gSLlog;
-  else if ( ! slconn->log )
+  else if (!slconn->log)
     logp = &gSLlog;
   else
     logp = slconn->log;
-  
+
   va_start (varlist, verb);
-  
+
   retval = sl_log_main (logp, level, verb, &varlist);
 
   va_end (varlist);
 
   return retval;
-}  /* End of sl_log_r() */
-
+} /* End of sl_log_r() */
 
 /***************************************************************************
  * sl_log_rl:
@@ -244,26 +237,25 @@ sl_log_r (const SLCD * slconn, int level, int verb, ...)
  * See sl_log_main() description for return values.
  ***************************************************************************/
 int
-sl_log_rl (SLlog * log, int level, int verb, ...)
+sl_log_rl (SLlog *log, int level, int verb, ...)
 {
   int retval;
   va_list varlist;
   SLlog *logp;
 
-  if ( ! log )
+  if (!log)
     logp = &gSLlog;
   else
     logp = log;
-  
+
   va_start (varlist, verb);
-  
+
   retval = sl_log_main (logp, level, verb, &varlist);
 
   va_end (varlist);
 
   return retval;
-}  /* End of sl_log_rl() */
-
+} /* End of sl_log_rl() */
 
 /***************************************************************************
  * sl_log_main:
@@ -275,7 +267,7 @@ sl_log_rl (SLlog * log, int level, int verb, ...)
  *
  * The function uses logging parameters specified in the supplied
  * SLlog.
- * 
+ *
  * This function expects 3+ arguments, message level, verbosity level,
  * fprintf format, and fprintf arguments.  If the verbosity level is
  * less than or equal to the set verbosity (see sl_loginit_main()),
@@ -303,94 +295,94 @@ sl_log_rl (SLlog * log, int level, int verb, ...)
  * a negative value on error.
  ***************************************************************************/
 int
-sl_log_main (SLlog * logp, int level, int verb, va_list * varlist)
+sl_log_main (SLlog *logp, int level, int verb, va_list *varlist)
 {
   static char message[MAX_LOG_MSG_LENGTH];
   int retvalue = 0;
-  
+
   message[0] = '\0';
 
   if (verb <= logp->verbosity)
+  {
+    int presize;
+    const char *format;
+
+    format = va_arg (*varlist, const char *);
+
+    if (level >= 2) /* Error message */
     {
-      int presize;
-      const char *format;
+      if (logp->errprefix != NULL)
+      {
+        strncpy (message, logp->errprefix, MAX_LOG_MSG_LENGTH);
+      }
+      else
+      {
+        strncpy (message, "error: ", MAX_LOG_MSG_LENGTH);
+      }
 
-      format = va_arg (*varlist, const char *);
+      presize  = strlen (message);
+      retvalue = vsnprintf (&message[presize],
+                            MAX_LOG_MSG_LENGTH - presize,
+                            format, *varlist);
 
-      if ( level >= 2 )  /* Error message */
-	{
-	  if ( logp->errprefix != NULL )
-	    {
-	      strncpy (message, logp->errprefix, MAX_LOG_MSG_LENGTH);
-	    }
-	  else
-	    {
-	      strncpy (message, "error: ", MAX_LOG_MSG_LENGTH);
-	    }
+      message[MAX_LOG_MSG_LENGTH - 1] = '\0';
 
-	  presize = strlen(message);
-	  retvalue = vsnprintf (&message[presize],
-				MAX_LOG_MSG_LENGTH - presize,
-				format, *varlist);
-
-	  message[MAX_LOG_MSG_LENGTH - 1] = '\0';
-
-	  if ( logp->diag_print != NULL )
-	    {
-	      logp->diag_print ((const char *) message);
-	    }
-	  else
-	    {
-	      fprintf(stderr, "%s", message);
-	    }
-	}
-      else if ( level == 1 )  /* Diagnostic message */
-	{
-	  if ( logp->logprefix != NULL )
-	    {
-	      strncpy (message, logp->logprefix, MAX_LOG_MSG_LENGTH);
-	    }
-
-	  presize = strlen(message);
-	  retvalue = vsnprintf (&message[presize],
-				MAX_LOG_MSG_LENGTH - presize,
-				format, *varlist);
-
-	  message[MAX_LOG_MSG_LENGTH - 1] = '\0';
-
-	  if ( logp->diag_print != NULL )
-	    {
-	      logp->diag_print ((const char *) message);
-	    }
-	  else
-	    {
-	      fprintf(stderr, "%s", message);
-	    }
-	}
-      else if ( level == 0 )  /* Normal log message */
-	{
-	  if ( logp->logprefix != NULL )
-	    {
-	      strncpy (message, logp->logprefix, MAX_LOG_MSG_LENGTH);
-	    }
-
-	  presize = strlen(message);
-	  retvalue = vsnprintf (&message[presize],
-				MAX_LOG_MSG_LENGTH - presize,
-				format, *varlist);
-
-	  message[MAX_LOG_MSG_LENGTH - 1] = '\0';
-
-	  if ( logp->log_print != NULL )
-	    {
-	      logp->log_print ((const char *) message);
-	    }
-	  else
-	    {
-	      fprintf(stdout, "%s", message);
-	    }
-	}
+      if (logp->diag_print != NULL)
+      {
+        logp->diag_print ((const char *)message);
+      }
+      else
+      {
+        fprintf (stderr, "%s", message);
+      }
     }
+    else if (level == 1) /* Diagnostic message */
+    {
+      if (logp->logprefix != NULL)
+      {
+        strncpy (message, logp->logprefix, MAX_LOG_MSG_LENGTH);
+      }
+
+      presize  = strlen (message);
+      retvalue = vsnprintf (&message[presize],
+                            MAX_LOG_MSG_LENGTH - presize,
+                            format, *varlist);
+
+      message[MAX_LOG_MSG_LENGTH - 1] = '\0';
+
+      if (logp->diag_print != NULL)
+      {
+        logp->diag_print ((const char *)message);
+      }
+      else
+      {
+        fprintf (stderr, "%s", message);
+      }
+    }
+    else if (level == 0) /* Normal log message */
+    {
+      if (logp->logprefix != NULL)
+      {
+        strncpy (message, logp->logprefix, MAX_LOG_MSG_LENGTH);
+      }
+
+      presize  = strlen (message);
+      retvalue = vsnprintf (&message[presize],
+                            MAX_LOG_MSG_LENGTH - presize,
+                            format, *varlist);
+
+      message[MAX_LOG_MSG_LENGTH - 1] = '\0';
+
+      if (logp->log_print != NULL)
+      {
+        logp->log_print ((const char *)message);
+      }
+      else
+      {
+        fprintf (stdout, "%s", message);
+      }
+    }
+  }
 
   return retvalue;
-}  /* End of sl_log_main() */
+} /* End of sl_log_main() */

--- a/bin/rt/slink2orb/libslink/msrecord.c
+++ b/bin/rt/slink2orb/libslink/msrecord.c
@@ -12,9 +12,9 @@
  *
  * Some ideas and structures were used from seedsniff 2.0
  *
- * Written by Chad Trabant, ORFEUS/EC-Project MEREDIAN
+ * Written by Chad Trabant, IRIS Data Managment Center
  *
- * modified: 2012.152
+ * modified: 2016.288
  ***************************************************************************/
 
 #include <stdio.h>
@@ -25,10 +25,11 @@
 #include "libslink.h"
 #include "unpack.h"
 
-/* Delcare routines only used in this source file */
-void encoding_hash (char enc, char *encstr);
-double host_latency (SLMSrecord * msr);
+#define SL_ISVALIDYEARDAY(Y, D) (Y >= 1900 && Y <= 2100 && D >= 1 && D <= 366)
 
+/* Declare routines only used in this source file */
+void encoding_hash (char enc, char *encstr);
+double host_latency (SLMSrecord *msr);
 
 /***************************************************************************
  * sl_msr_new:
@@ -39,17 +40,17 @@ double host_latency (SLMSrecord * msr);
  *  or NULL on error.
  ***************************************************************************/
 SLMSrecord *
-sl_msr_new ( void )
+sl_msr_new (void)
 {
-  SLMSrecord * msr;
-  
-  msr = (SLMSrecord *) malloc (sizeof(SLMSrecord));
-  
-  if ( msr == NULL )
-    {
-      sl_log_rl (NULL, 2, 0, "sl_msr_new(): error allocating memory\n");
-      return NULL;
-    }
+  SLMSrecord *msr;
+
+  msr = (SLMSrecord *)malloc (sizeof (SLMSrecord));
+
+  if (msr == NULL)
+  {
+    sl_log_rl (NULL, 2, 0, "sl_msr_new(): error allocating memory\n");
+    return NULL;
+  }
 
   msr->fsdh.sequence_number[0] = '\0';
   msr->fsdh.dhq_indicator      = 0;
@@ -75,19 +76,18 @@ sl_msr_new ( void )
   msr->fsdh.time_correct       = 0;
   msr->fsdh.begin_data         = 0;
   msr->fsdh.begin_blockette    = 0;
-  
-  msr->Blkt100     = NULL;
-  msr->Blkt1000    = NULL;
-  msr->Blkt1001    = NULL;
-  
+
+  msr->Blkt100  = NULL;
+  msr->Blkt1000 = NULL;
+  msr->Blkt1001 = NULL;
+
   msr->msrecord    = NULL;
   msr->datasamples = NULL;
   msr->numsamples  = -1;
   msr->unpackerr   = MSD_NOERROR;
-  
-  return msr;
-}  /* End of sl_msr_new() */
 
+  return msr;
+} /* End of sl_msr_new() */
 
 /***************************************************************************
  * sl_msr_free:
@@ -96,36 +96,50 @@ sl_msr_new ( void )
  * record indicated by the element 'msrecord'.
  ***************************************************************************/
 void
-sl_msr_free ( SLMSrecord ** msr )
+sl_msr_free (SLMSrecord **msr)
 {
-  if ( msr != NULL && *msr != NULL )
-    {
-      free((*msr)->Blkt100);
-      free((*msr)->Blkt1000);
-      free((*msr)->Blkt1001);
+  if (msr != NULL && *msr != NULL)
+  {
+    free ((*msr)->Blkt100);
+    free ((*msr)->Blkt1000);
+    free ((*msr)->Blkt1001);
 
-      if ( (*msr)->datasamples != NULL )
-	free((*msr)->datasamples);
+    if ((*msr)->datasamples != NULL)
+      free ((*msr)->datasamples);
 
-      free(*msr);
-      
-      *msr = NULL;
-    }
-}  /* End of sl_msr_free() */
+    free (*msr);
 
+    *msr = NULL;
+  }
+} /* End of sl_msr_free() */
+
+/***************************************************************************
+ * sl_littleendianhost:
+ *
+ * Determine the byte order of the host machine.  Due to the lack of
+ * portable defines to determine host byte order this run-time test is
+ * provided.  This function originated from a similar function in libmseed.
+ *
+ * Returns 1 if the host is little endian, otherwise 0.
+ ***************************************************************************/
+static uint8_t
+sl_littleendianhost (void)
+{
+  uint16_t host = 1;
+  return *((uint8_t *)(&host));
+} /* End of sl_littleendianhost() */
 
 /***************************************************************************
  * sl_msr_parse:
  *
- * A wrapper for sl_msr_parse_size() 
+ * A wrapper for sl_msr_parse_size()
  ***************************************************************************/
 SLMSrecord *
-sl_msr_parse (SLlog * log, const char * msrecord, SLMSrecord ** ppmsr,
-	      int8_t blktflag, int8_t unpackflag)
+sl_msr_parse (SLlog *log, const char *msrecord, SLMSrecord **ppmsr,
+              int8_t blktflag, int8_t unpackflag)
 {
   return sl_msr_parse_size (log, msrecord, ppmsr, blktflag, unpackflag, SLRECSIZE);
 }
-
 
 /***************************************************************************
  * sl_msr_parse_size:
@@ -161,191 +175,200 @@ sl_msr_parse (SLlog * log, const char * msrecord, SLMSrecord ** ppmsr,
  * checked before passing it to sl_msr_parse_size().
  ***************************************************************************/
 SLMSrecord *
-sl_msr_parse_size (SLlog * log, const char * msrecord, SLMSrecord ** ppmsr,
-		   int8_t blktflag, int8_t unpackflag, int slrecsize)
+sl_msr_parse_size (SLlog *log, const char *msrecord, SLMSrecord **ppmsr,
+                   int8_t blktflag, int8_t unpackflag, int slrecsize)
 {
-  int swapflag = 0;		        /* is swapping needed? */
-  uint16_t begin_blockette;	        /* byte offset for next blockette */
-  SLMSrecord * msr = NULL;
+  uint8_t headerswapflag = 0; /* is swapping needed? */
+  uint8_t dataswapflag   = 0;
+  SLMSrecord *msr        = NULL;
 
-  if ( ppmsr == NULL )
-    {
-      sl_log_rl (log, 2, 1, "msr_parse(): pointer to SLMSrecord cannot be NULL\n");
-      *ppmsr = NULL;
-      return NULL;
-    }
+  if (ppmsr == NULL)
+  {
+    sl_log_rl (log, 2, 1, "msr_parse(): pointer to SLMSrecord cannot be NULL\n");
+    *ppmsr = NULL;
+    return NULL;
+  }
   else
-    {
-      msr = * ppmsr;
-    }
+  {
+    msr = *ppmsr;
+  }
 
   /* If this record is new init a new one otherwise clean it up */
-  if ( msr == NULL )
-    {
-      msr = sl_msr_new();
-    }
+  if (msr == NULL)
+  {
+    msr = sl_msr_new ();
+  }
   else
+  {
+    if (msr->Blkt100 != NULL)
     {
-      if ( msr->Blkt100 != NULL )
-	{
-	  free (msr->Blkt100);
-	  msr->Blkt100 = NULL;
-	}
-      if ( msr->Blkt1000 != NULL )
-	{
-	  free (msr->Blkt1000);
-	  msr->Blkt1000 = NULL;
-	}
-
-      if ( msr->Blkt1001 != NULL )
-	{
-	  free (msr->Blkt1001);
-	  msr->Blkt1001 = NULL;
-	}
-
-      if ( msr->datasamples != NULL )
-	{
-	  free (msr->datasamples);
-	  msr->datasamples = NULL;
-	}
+      free (msr->Blkt100);
+      msr->Blkt100 = NULL;
     }
+    if (msr->Blkt1000 != NULL)
+    {
+      free (msr->Blkt1000);
+      msr->Blkt1000 = NULL;
+    }
+
+    if (msr->Blkt1001 != NULL)
+    {
+      free (msr->Blkt1001);
+      msr->Blkt1001 = NULL;
+    }
+
+    if (msr->datasamples != NULL)
+    {
+      free (msr->datasamples);
+      msr->datasamples = NULL;
+    }
+  }
 
   msr->msrecord = msrecord;
 
   /* Copy the fixed section into msr */
-  memcpy ((void *) &msr->fsdh, msrecord, 48);
+  memcpy ((void *)&msr->fsdh, msrecord, 48);
 
   /* Sanity check for msr/quality indicator */
   if (msr->fsdh.dhq_indicator != 'D' &&
       msr->fsdh.dhq_indicator != 'R' &&
       msr->fsdh.dhq_indicator != 'Q')
-    {
-      sl_log_rl (log, 2, 0, "record header/quality indicator unrecognized: %c\n",
-		 msr->fsdh.dhq_indicator);
-      sl_msr_free(&msr);
-      *ppmsr = NULL;
-      return NULL;
-    }
+  {
+    sl_log_rl (log, 2, 0, "record header/quality indicator unrecognized: %c\n",
+               msr->fsdh.dhq_indicator);
+    sl_msr_free (&msr);
+    *ppmsr = NULL;
+    return NULL;
+  }
 
-  /* Check to see if byte swapping is needed (bogus year makes good test) */
-  if ((msr->fsdh.start_time.year < 1900) ||
-      (msr->fsdh.start_time.year > 2050))
-    swapflag = 1;
-  
+  /* Check to see if byte swapping is needed by testing the year and day */
+  if (!SL_ISVALIDYEARDAY (msr->fsdh.start_time.year, msr->fsdh.start_time.day))
+    headerswapflag = dataswapflag = 1;
+
   /* Change byte order? */
-  if ( swapflag )
-    {
-      SL_SWAPBTIME (&msr->fsdh.start_time);
-      sl_gswap2 (&msr->fsdh.num_samples);
-      sl_gswap2 (&msr->fsdh.samprate_fact);
-      sl_gswap2 (&msr->fsdh.samprate_mult);
-      sl_gswap4 (&msr->fsdh.time_correct);
-      sl_gswap2 (&msr->fsdh.begin_data);
-      sl_gswap2 (&msr->fsdh.begin_blockette);
-    }
+  if (headerswapflag)
+  {
+    SL_SWAPBTIME (&msr->fsdh.start_time);
+    sl_gswap2 (&msr->fsdh.num_samples);
+    sl_gswap2 (&msr->fsdh.samprate_fact);
+    sl_gswap2 (&msr->fsdh.samprate_mult);
+    sl_gswap4 (&msr->fsdh.time_correct);
+    sl_gswap2 (&msr->fsdh.begin_data);
+    sl_gswap2 (&msr->fsdh.begin_blockette);
+  }
 
   /* Parse the blockettes if requested */
-  if ( blktflag )
+  if (blktflag)
+  {
+    /* Define some structures */
+    struct sl_blkt_head_s *blkt_head;
+    struct sl_blkt_100_s *blkt_100;
+    struct sl_blkt_1000_s *blkt_1000;
+    struct sl_blkt_1001_s *blkt_1001;
+    uint16_t begin_blockette; /* byte offset for next blockette */
+
+    /* Initialize the blockette structures */
+    blkt_head = (struct sl_blkt_head_s *)malloc (sizeof (struct sl_blkt_head_s));
+    blkt_100  = NULL;
+    blkt_1000 = NULL;
+    blkt_1001 = NULL;
+
+    /* loop through blockettes as long as number is non-zero and viable */
+    begin_blockette = msr->fsdh.begin_blockette;
+
+    while ((begin_blockette != 0) &&
+           (begin_blockette <= slrecsize))
     {
-      /* Define some structures */
-      struct sl_blkt_head_s  *blkt_head;
-      struct sl_blkt_100_s   *blkt_100;
-      struct sl_blkt_1000_s  *blkt_1000;
-      struct sl_blkt_1001_s  *blkt_1001;
-      
-      /* Initialize the blockette structures */
-      blkt_head = (struct sl_blkt_head_s *) malloc (sizeof (struct sl_blkt_head_s));
-      blkt_100  = NULL;
-      blkt_1000 = NULL;
-      blkt_1001 = NULL;
 
-      /* loop through blockettes as long as number is non-zero and viable */
-      begin_blockette = msr->fsdh.begin_blockette;
-      
-      while ((begin_blockette != 0) &&
-	     (begin_blockette <= slrecsize))
-	{
-	  
-	  memcpy ((void *) blkt_head, msrecord + begin_blockette,
-		  sizeof (struct sl_blkt_head_s));
-	  if ( swapflag )
-	    {
-	      sl_gswap2 (&blkt_head->blkt_type);
-	      sl_gswap2 (&blkt_head->next_blkt);
-	    }
+      memcpy ((void *)blkt_head, msrecord + begin_blockette,
+              sizeof (struct sl_blkt_head_s));
+      if (headerswapflag)
+      {
+        sl_gswap2 (&blkt_head->blkt_type);
+        sl_gswap2 (&blkt_head->next_blkt);
+      }
 
-	  if (blkt_head->blkt_type == 100)
-	    {			/* found a 100 blockette */
-	      blkt_100 = (struct sl_blkt_100_s *) malloc (sizeof (struct sl_blkt_100_s));
-	      memcpy ((void *) blkt_100, msrecord + begin_blockette,
-		      sizeof (struct sl_blkt_100_s));
-	      
-	      if ( swapflag )
-		{
-		  sl_gswap4 (&blkt_100->sample_rate);
-		}
-	      
-	      blkt_100->blkt_type = blkt_head->blkt_type;
-	      blkt_100->next_blkt = blkt_head->next_blkt;
-	      
-	      msr->Blkt100 = blkt_100;
-	    }
-	  
-	  if (blkt_head->blkt_type == 1000)
-	    
-	    {			/* found the 1000 blockette */
-	      blkt_1000 =
-		(struct sl_blkt_1000_s *) malloc (sizeof (struct sl_blkt_1000_s));
-	      memcpy ((void *) blkt_1000, msrecord + begin_blockette,
-		      sizeof (struct sl_blkt_1000_s));
-	      
-	      blkt_1000->blkt_type = blkt_head->blkt_type;
-	      blkt_1000->next_blkt = blkt_head->next_blkt;
-	      
-	      msr->Blkt1000 = blkt_1000;
-	    }
-	  
-	  if (blkt_head->blkt_type == 1001)
-	    {			/* found a 1001 blockette */
-	      blkt_1001 =
-		(struct sl_blkt_1001_s *) malloc (sizeof (struct sl_blkt_1001_s));
-	      memcpy ((void *) blkt_1001, msrecord + begin_blockette,
-		      sizeof (struct sl_blkt_1001_s));
-	      
-	      blkt_1001->blkt_type = blkt_head->blkt_type;
-	      blkt_1001->next_blkt = blkt_head->next_blkt;
-	      
-	      msr->Blkt1001 = blkt_1001;
-	    }
-	  
-	  /* Point to the next blockette */
-	  begin_blockette = blkt_head->next_blkt;
-	}				/* End of while looping through blockettes */
-      
-      if (blkt_1000 == NULL)
-	{
-	  sl_log_rl (log, 1, 0, "1000 blockette was NOT found for %s.%s.%s.%s!",
-		     msr->fsdh.network, msr->fsdh.station,
-		     msr->fsdh.location, msr->fsdh.channel);
-	}
-      
-      free (blkt_head);
+      if (blkt_head->blkt_type == 100)
+      { /* found a 100 blockette */
+        blkt_100 = (struct sl_blkt_100_s *)malloc (sizeof (struct sl_blkt_100_s));
+        memcpy ((void *)blkt_100, msrecord + begin_blockette,
+                sizeof (struct sl_blkt_100_s));
+
+        if (headerswapflag)
+        {
+          sl_gswap4 (&blkt_100->sample_rate);
+        }
+
+        blkt_100->blkt_type = blkt_head->blkt_type;
+        blkt_100->next_blkt = blkt_head->next_blkt;
+
+        msr->Blkt100 = blkt_100;
+      }
+
+      if (blkt_head->blkt_type == 1000)
+
+      { /* found the 1000 blockette */
+        blkt_1000 =
+            (struct sl_blkt_1000_s *)malloc (sizeof (struct sl_blkt_1000_s));
+        memcpy ((void *)blkt_1000, msrecord + begin_blockette,
+                sizeof (struct sl_blkt_1000_s));
+
+        blkt_1000->blkt_type = blkt_head->blkt_type;
+        blkt_1000->next_blkt = blkt_head->next_blkt;
+
+        msr->Blkt1000 = blkt_1000;
+      }
+
+      if (blkt_head->blkt_type == 1001)
+      { /* found a 1001 blockette */
+        blkt_1001 =
+            (struct sl_blkt_1001_s *)malloc (sizeof (struct sl_blkt_1001_s));
+        memcpy ((void *)blkt_1001, msrecord + begin_blockette,
+                sizeof (struct sl_blkt_1001_s));
+
+        blkt_1001->blkt_type = blkt_head->blkt_type;
+        blkt_1001->next_blkt = blkt_head->next_blkt;
+
+        msr->Blkt1001 = blkt_1001;
+      }
+
+      /* Point to the next blockette */
+      begin_blockette = blkt_head->next_blkt;
+    } /* End of while looping through blockettes */
+
+    if (blkt_1000 == NULL)
+    {
+      sl_log_rl (log, 1, 0, "1000 blockette was NOT found for %s.%s.%s.%s!",
+                 msr->fsdh.network, msr->fsdh.station,
+                 msr->fsdh.location, msr->fsdh.channel);
     }
+    else
+    {
+      /* no byte swapping of data if little-endian host and little-endian data */
+      if (sl_littleendianhost () && blkt_1000->word_swap == 0)
+        dataswapflag = 0;
+      /* no byte swapping of data if big-endian host and big-endian data */
+      else if (!sl_littleendianhost () && blkt_1000->word_swap == 1)
+        dataswapflag = 0;
+    }
+
+    free (blkt_head);
+  }
 
   /* Unpack the data samples if requested */
-  if ( unpackflag )
-    {
-      msr->numsamples = sl_msr_unpack (log, msr, swapflag);
-    }
-  else {
+  if (unpackflag)
+  {
+    msr->numsamples = sl_msr_unpack (log, msr, dataswapflag);
+  }
+  else
+  {
     msr->numsamples = -1;
   }
 
   /* Re-direct the original pointer and return the new */
   *ppmsr = msr;
   return msr;
-}  /* End of sl_msr_parse() */
-
+} /* End of sl_msr_parse_size() */
 
 /***************************************************************************
  * sl_msr_print:
@@ -357,142 +380,164 @@ sl_msr_parse_size (SLlog * log, const char * msrecord, SLMSrecord ** ppmsr,
  * Returns non-zero on success or 0 on error.
  ***************************************************************************/
 int
-sl_msr_print (SLlog * log, SLMSrecord * msr, int details)
+sl_msr_print (SLlog *log, SLMSrecord *msr, int details)
 {
   char sourcename[50];
-  char prtnet[4], prtsta[7];
-  char prtloc[4], prtchan[5];
   char stime[25];
   double latency;
   double dsamprate = 0.0;
   int usec;
 
-  /* Generate clean identifier strings */
-  sl_strncpclean (prtnet, msr->fsdh.network, 2);
-  sl_strncpclean (prtsta, msr->fsdh.station, 5);
-  sl_strncpclean (prtloc, msr->fsdh.location, 2);
-  sl_strncpclean (prtchan, msr->fsdh.channel, 3);
-
-  if (prtnet[0] != '\0')
-    strcat (prtnet, "_");
-  if (prtsta[0] != '\0')
-    strcat (prtsta, "_");
-  if (prtloc[0] != '\0')
-    strcat (prtloc, "_");
-
   /* Build the source name string */
-  sprintf (sourcename, "%.3s%.6s%.3s%.3s", prtnet, prtsta, prtloc, prtchan);
+  sl_msr_srcname (msr, sourcename, 0);
 
   usec = msr->fsdh.start_time.fract * 100;
-  
-  if ( msr->Blkt1001 )
+
+  if (msr->Blkt1001)
+  {
+    usec += msr->Blkt1001->usec;
+
+    if (usec > 1000000 || usec < 0)
     {
-      usec += msr->Blkt1001->usec;
-      
-      if ( usec > 1000000 || usec < 0 )
-	{
-	  sl_log_rl (log, 1, 0, "Cannot apply microsecond offset\n");
-	  usec -= msr->Blkt1001->usec;
-	}
+      sl_log_rl (log, 1, 0, "Cannot apply microsecond offset\n");
+      usec -= msr->Blkt1001->usec;
     }
+  }
 
   /* Build a start time string */
-  snprintf (stime, sizeof(stime), "%04d,%03d,%02d:%02d:%02d.%06d",
-	    msr->fsdh.start_time.year, msr->fsdh.start_time.day,
-	    msr->fsdh.start_time.hour, msr->fsdh.start_time.min,
-	    msr->fsdh.start_time.sec, usec);
-  
+  snprintf (stime, sizeof (stime), "%04d,%03d,%02d:%02d:%02d.%06d",
+            msr->fsdh.start_time.year, msr->fsdh.start_time.day,
+            msr->fsdh.start_time.hour, msr->fsdh.start_time.min,
+            msr->fsdh.start_time.sec, usec);
+
   /* Calculate the latency */
   latency = host_latency (msr);
-  
+
   /* Report information in the fixed header */
   if (details > 0)
-    {
-      dsamprate = sl_msr_dnomsamprate(msr);
-      sl_log_rl (log, 0, 0, "                 source: %s\n", sourcename);
-      sl_log_rl (log, 0, 0, "             start time: %s  (latency ~%1.1f sec)\n",
-		 stime, latency);
-      sl_log_rl (log, 0, 0, "      number of samples: %d\n", msr->fsdh.num_samples);
-      sl_log_rl (log, 0, 0, "     sample rate factor: %d\n", msr->fsdh.samprate_fact);
-      sl_log_rl (log, 0, 0, " sample rate multiplier: %d  (%.10g samples per second)\n",
-		 msr->fsdh.samprate_mult, dsamprate);
-      sl_log_rl (log, 0, 0, "     num. of blockettes: %d\n",
-		 msr->fsdh.num_blockettes);
-      sl_log_rl (log, 0, 0, "        time correction: %ld\n",
-		 msr->fsdh.time_correct);
-      sl_log_rl (log, 0, 0, "      begin data offset: %d\n", msr->fsdh.begin_data);
-      sl_log_rl (log, 0, 0, "  fist blockette offset: %d\n",
-		 msr->fsdh.begin_blockette);
-    }
+  {
+    dsamprate = sl_msr_dnomsamprate (msr);
+    sl_log_rl (log, 0, 0, "                 source: %s\n", sourcename);
+    sl_log_rl (log, 0, 0, "             start time: %s  (latency ~%1.1f sec)\n",
+               stime, latency);
+    sl_log_rl (log, 0, 0, "      number of samples: %d\n", msr->fsdh.num_samples);
+    sl_log_rl (log, 0, 0, "     sample rate factor: %d\n", msr->fsdh.samprate_fact);
+    sl_log_rl (log, 0, 0, " sample rate multiplier: %d  (%.10g samples per second)\n",
+               msr->fsdh.samprate_mult, dsamprate);
+    sl_log_rl (log, 0, 0, "     num. of blockettes: %d\n",
+               msr->fsdh.num_blockettes);
+    sl_log_rl (log, 0, 0, "        time correction: %ld\n",
+               msr->fsdh.time_correct);
+    sl_log_rl (log, 0, 0, "      begin data offset: %d\n", msr->fsdh.begin_data);
+    sl_log_rl (log, 0, 0, "  fist blockette offset: %d\n",
+               msr->fsdh.begin_blockette);
+  }
   else
-    {
-      sl_msr_dsamprate (msr, &dsamprate);
-      sl_log_rl (log, 0, 0, "%s, %d samples, %.10g Hz, %s (latency ~%1.1f sec)\n",
-		 sourcename, msr->fsdh.num_samples, dsamprate, stime, latency);
-    }
+  {
+    sl_msr_dsamprate (msr, &dsamprate);
+    sl_log_rl (log, 0, 0, "%s, %d samples, %.10g Hz, %s (latency ~%1.1f sec)\n",
+               sourcename, msr->fsdh.num_samples, dsamprate, stime, latency);
+  }
 
   if (details > 0)
+  {
+    if (msr->Blkt100 != NULL)
     {
-      if ( msr->Blkt100 != NULL )
-	{
-	  sl_log_rl (log, 0, 0, "          BLOCKETTE 100:\n");
-	  sl_log_rl (log, 0, 0, "              next blockette: %d\n",
-		     msr->Blkt100->next_blkt);
-	  sl_log_rl (log, 0, 0, "          actual sample rate: %.4f\n",
-		     msr->Blkt100->sample_rate);
-	  sl_log_rl (log, 0, 0, "                       flags: %d\n",
-		     msr->Blkt100->flags);
-	}
-      
-      if ( msr->Blkt1000 != NULL )
-	{
-	  int reclen;
-	  char order[40];
-	  char encstr[100];
-
-	  encoding_hash (msr->Blkt1000->encoding, &encstr[0]);
-	  
-	  /* Calculate record size in bytes as 2^(Blkt1000->rec_len) */
-	  reclen = (unsigned int) 1 << msr->Blkt1000->rec_len;
-	  
-	  /* Big or little endian reported by the 1000 blockette? */
-	  if (msr->Blkt1000->word_swap == 0)
-	    strncpy (order, "Little endian (Intel/VAX)", sizeof(order)-1);
-	  else if (msr->Blkt1000->word_swap == 1)
-	    strncpy (order, "Big endian (SPARC/Motorola)", sizeof(order)-1);
-	  else
-	    strncpy (order, "Unknown value", sizeof(order)-1);
-	  
-	  sl_log_rl (log, 0, 0, "         BLOCKETTE 1000:\n");
-	  sl_log_rl (log, 0, 0, "              next blockette: %d\n",
-		     msr->Blkt1000->next_blkt);
-	  sl_log_rl (log, 0, 0, "                    encoding: %s\n", encstr);
-	  sl_log_rl (log, 0, 0, "                  byte order: %s\n", order);
-	  sl_log_rl (log, 0, 0, "               record length: %d (val:%d)\n",
-		     reclen, msr->Blkt1000->rec_len);
-	  sl_log_rl (log, 0, 0, "                    reserved: %d\n",
-		     msr->Blkt1000->reserved);
-	}
-      
-      if ( msr->Blkt1001 != NULL )
-	{
-	  sl_log_rl (log, 0, 0, "         BLOCKETTE 1001:\n");
-	  sl_log_rl (log, 0, 0, "              next blockette: %d\n",
-		     msr->Blkt1001->next_blkt);
-	  sl_log_rl (log, 0, 0, "              timing quality: %d%%\n",
-		     msr->Blkt1001->timing_qual);
-	  sl_log_rl (log, 0, 0, "                micro second: %d\n",
-		     msr->Blkt1001->usec);
-	  sl_log_rl (log, 0, 0, "                    reserved: %d\n",
-		     msr->Blkt1001->reserved);
-	  sl_log_rl (log, 0, 0, "                 frame count: %d\n",
-		     msr->Blkt1001->frame_cnt);
-	}
+      sl_log_rl (log, 0, 0, "          BLOCKETTE 100:\n");
+      sl_log_rl (log, 0, 0, "              next blockette: %d\n",
+                 msr->Blkt100->next_blkt);
+      sl_log_rl (log, 0, 0, "          actual sample rate: %.4f\n",
+                 msr->Blkt100->sample_rate);
+      sl_log_rl (log, 0, 0, "                       flags: %d\n",
+                 msr->Blkt100->flags);
     }
-  
-  return 1;
-}  /* End of sl_msr_print() */
 
+    if (msr->Blkt1000 != NULL)
+    {
+      int reclen;
+      char order[40];
+      char encstr[100];
+
+      encoding_hash (msr->Blkt1000->encoding, &encstr[0]);
+
+      /* Calculate record size in bytes as 2^(Blkt1000->rec_len) */
+      reclen = (unsigned int)1 << msr->Blkt1000->rec_len;
+
+      /* Big or little endian reported by the 1000 blockette? */
+      if (msr->Blkt1000->word_swap == 0)
+        strncpy (order, "Little endian (Intel/VAX)", sizeof (order) - 1);
+      else if (msr->Blkt1000->word_swap == 1)
+        strncpy (order, "Big endian (SPARC/Motorola)", sizeof (order) - 1);
+      else
+        strncpy (order, "Unknown value", sizeof (order) - 1);
+
+      sl_log_rl (log, 0, 0, "         BLOCKETTE 1000:\n");
+      sl_log_rl (log, 0, 0, "              next blockette: %d\n",
+                 msr->Blkt1000->next_blkt);
+      sl_log_rl (log, 0, 0, "                    encoding: %s\n", encstr);
+      sl_log_rl (log, 0, 0, "                  byte order: %s\n", order);
+      sl_log_rl (log, 0, 0, "               record length: %d (val:%d)\n",
+                 reclen, msr->Blkt1000->rec_len);
+      sl_log_rl (log, 0, 0, "                    reserved: %d\n",
+                 msr->Blkt1000->reserved);
+    }
+
+    if (msr->Blkt1001 != NULL)
+    {
+      sl_log_rl (log, 0, 0, "         BLOCKETTE 1001:\n");
+      sl_log_rl (log, 0, 0, "              next blockette: %d\n",
+                 msr->Blkt1001->next_blkt);
+      sl_log_rl (log, 0, 0, "              timing quality: %d%%\n",
+                 msr->Blkt1001->timing_qual);
+      sl_log_rl (log, 0, 0, "                micro second: %d\n",
+                 msr->Blkt1001->usec);
+      sl_log_rl (log, 0, 0, "                    reserved: %d\n",
+                 msr->Blkt1001->reserved);
+      sl_log_rl (log, 0, 0, "                 frame count: %d\n",
+                 msr->Blkt1001->frame_cnt);
+    }
+  }
+
+  return 1;
+} /* End of sl_msr_print() */
+
+/***************************************************************************
+ * sl_ms_srcname:
+ *
+ * Generate a source name string for a specified raw data record in
+ * the format: 'NET_STA_LOC_CHAN' or, if the quality flag is true:
+ * 'NET_STA_LOC_CHAN_QUAL'.  The passed srcname must have enough room
+ * for the resulting string.
+ *
+ * Returns a pointer to the resulting string or NULL on error.
+ ***************************************************************************/
+char *
+sl_msr_srcname (SLMSrecord *msr, char *srcname, int8_t quality)
+{
+  char network[8];
+  char station[8];
+  char location[8];
+  char channel[8];
+
+  if (!msr)
+    return NULL;
+
+  sl_strncpclean (network, msr->fsdh.network, 2);
+  sl_strncpclean (station, msr->fsdh.station, 5);
+  sl_strncpclean (location, msr->fsdh.location, 2);
+  sl_strncpclean (channel, msr->fsdh.channel, 3);
+
+  /* Build the source name string including the quality indicator*/
+  if (quality)
+    sprintf (srcname, "%s_%s_%s_%s_%c",
+             network, station, location, channel, msr->fsdh.dhq_indicator);
+
+  /* Build the source name string without the quality indicator*/
+  else
+    sprintf (srcname, "%s_%s_%s_%s", network, station, location, channel);
+
+  return srcname;
+} /* End of sl_msr_srcname() */
 
 /***************************************************************************
  * sl_msr_dsamprate:
@@ -508,27 +553,26 @@ sl_msr_print (SLlog * log, SLMSrecord * msr, int details)
  * rate (from factor and multiplier) or 0 on error.
  ***************************************************************************/
 int
-sl_msr_dsamprate (SLMSrecord * msr, double * samprate)
+sl_msr_dsamprate (SLMSrecord *msr, double *samprate)
 {
-  if ( ! msr )
+  if (!msr)
     return 0;
 
-  if ( msr->Blkt100 )
-    {
-      *samprate = (double) msr->Blkt100->sample_rate;
-      return 1;
-    }
+  if (msr->Blkt100)
+  {
+    *samprate = (double)msr->Blkt100->sample_rate;
+    return 1;
+  }
   else
-    {
-      *samprate = sl_msr_dnomsamprate(msr);
-      
-      if ( *samprate == -1.0 )
-	return 0;
-      
-      return 2;
-    }
-}  /* End of sl_msr_dsamprate() */
+  {
+    *samprate = sl_msr_dnomsamprate (msr);
 
+    if (*samprate == -1.0)
+      return 0;
+
+    return 2;
+  }
+} /* End of sl_msr_dsamprate() */
 
 /***************************************************************************
  * sl_msr_dnomsamprate:
@@ -540,32 +584,31 @@ sl_msr_dsamprate (SLMSrecord * msr, double * samprate)
  * Returns the nominal sample rate or -1.0 on error.
  ***************************************************************************/
 double
-sl_msr_dnomsamprate (SLMSrecord * msr)
+sl_msr_dnomsamprate (SLMSrecord *msr)
 {
   double srcalc = 0.0;
   int factor;
   int multiplier;
-  
-  if ( ! msr )
-    return -1.0;
-  
-  /* Calculate the nominal sample rate */  
-  factor = msr->fsdh.samprate_fact;
-  multiplier = msr->fsdh.samprate_mult;
-  
-  if ( factor > 0 )
-    srcalc = (double) factor;
-  else if ( factor < 0 )
-    srcalc = -1.0 / (double) factor;
-  
-  if ( multiplier > 0 )
-    srcalc = srcalc * (double) multiplier;
-  else if ( multiplier < 0 )
-    srcalc = -1.0 * (srcalc / (double) multiplier);
-  
-  return srcalc;
-}  /* End of sl_msr_dnomsamprate() */
 
+  if (!msr)
+    return -1.0;
+
+  /* Calculate the nominal sample rate */
+  factor     = msr->fsdh.samprate_fact;
+  multiplier = msr->fsdh.samprate_mult;
+
+  if (factor > 0)
+    srcalc = (double)factor;
+  else if (factor < 0)
+    srcalc = -1.0 / (double)factor;
+
+  if (multiplier > 0)
+    srcalc = srcalc * (double)multiplier;
+  else if (multiplier < 0)
+    srcalc = -1.0 * (srcalc / (double)multiplier);
+
+  return srcalc;
+} /* End of sl_msr_dnomsamprate() */
 
 /***************************************************************************
  * sl_msr_depochstime:
@@ -577,32 +620,31 @@ sl_msr_dnomsamprate (SLMSrecord * msr)
  * Returns double precision epoch time or 0 for error.
  ***************************************************************************/
 double
-sl_msr_depochstime (SLMSrecord * msr)
+sl_msr_depochstime (SLMSrecord *msr)
 {
   struct sl_btime_s *btime;
   double dtime;
-  
-  if ( ! msr )
+
+  if (!msr)
     return 0;
-  
+
   btime = &msr->fsdh.start_time;
-  
-  dtime = (double) (btime->year - 1970) * 31536000 +
-                   ((btime->year - 1969) / 4) * 86400 +
-                   (btime->day - 1) * 86400 +
-                   btime->hour * 3600 +
-                   btime->min * 60 +
-                   btime->sec +
-                   (double) btime->fract / 10000.0;
 
-  if ( msr->Blkt1001 )
-    {
-      dtime += msr->Blkt1001->usec / 1000000;
-    }
-  
+  dtime = (double)(btime->year - 1970) * 31536000 +
+          ((btime->year - 1969) / 4) * 86400 +
+          (btime->day - 1) * 86400 +
+          btime->hour * 3600 +
+          btime->min * 60 +
+          btime->sec +
+          (double)btime->fract / 10000.0;
+
+  if (msr->Blkt1001)
+  {
+    dtime += msr->Blkt1001->usec / 1000000;
+  }
+
   return dtime;
-}  /* End of sl_msr_depochstime() */
-
+} /* End of sl_msr_depochstime() */
 
 /***************************************************************************
  * encoding_hash:
@@ -613,73 +655,72 @@ void
 encoding_hash (char enc, char *encstr)
 {
   switch (enc)
-    {
-    case 0:
-      strcpy (encstr, "ASCII text (val:0)");
-      break;
-    case 1:
-      strcpy (encstr, "16 bit integers (val:1)");
-      break;
-    case 2:
-      strcpy (encstr, "24 bit integers (val:2)");
-      break;
-    case 3:
-      strcpy (encstr, "32 bit integers (val:3)");
-      break;
-    case 4:
-      strcpy (encstr, "IEEE floating point (val:4)");
-      break;
-    case 5:
-      strcpy (encstr, "IEEE double precision float (val:5)");
-      break;
-    case 10:
-      strcpy (encstr, "STEIM 1 Compression (val:10)");
-      break;
-    case 11:
-      strcpy (encstr, "STEIM 2 Compression (val:11)");
-      break;
-    case 12:
-      strcpy (encstr, "GEOSCOPE Muxed 24 bit int (val:12)");
-      break;
-    case 13:
-      strcpy (encstr, "GEOSCOPE Muxed 16/3 bit gain/exp (val:13)");
-      break;
-    case 14:
-      strcpy (encstr, "GEOSCOPE Muxed 16/4 bit gain/exp (val:14)");
-      break;
-    case 15:
-      strcpy (encstr, "US National Network compression (val:15)");
-      break;
-    case 16:
-      strcpy (encstr, "CDSN 16 bit gain ranged (val:16)");
-      break;
-    case 17:
-      strcpy (encstr, "Graefenberg 16 bit gain ranged (val:17)");
-      break;
-    case 18:
-      strcpy (encstr, "IPG - Strasbourg 16 bit gain (val:18)");
-      break;
-    case 19:
-      strcpy (encstr, "STEIM 3 Compression (val:19)");
-      break;
-    case 30:
-      strcpy (encstr, "SRO Format (val:30)");
-      break;
-    case 31:
-      strcpy (encstr, "HGLP Format (val:31)");
-      break;
-    case 32:
-      strcpy (encstr, "DWWSSN Gain Ranged Format (val:32)");
-      break;
-    case 33:
-      strcpy (encstr, "RSTN 16 bit gain ranged (val:33)");
-      break;
-    default:
-      sprintf (encstr, "Unknown format code: (%d)", enc);
-    }				/* end switch */
+  {
+  case 0:
+    strcpy (encstr, "ASCII text (val:0)");
+    break;
+  case 1:
+    strcpy (encstr, "16 bit integers (val:1)");
+    break;
+  case 2:
+    strcpy (encstr, "24 bit integers (val:2)");
+    break;
+  case 3:
+    strcpy (encstr, "32 bit integers (val:3)");
+    break;
+  case 4:
+    strcpy (encstr, "IEEE floating point (val:4)");
+    break;
+  case 5:
+    strcpy (encstr, "IEEE double precision float (val:5)");
+    break;
+  case 10:
+    strcpy (encstr, "STEIM 1 Compression (val:10)");
+    break;
+  case 11:
+    strcpy (encstr, "STEIM 2 Compression (val:11)");
+    break;
+  case 12:
+    strcpy (encstr, "GEOSCOPE Muxed 24 bit int (val:12)");
+    break;
+  case 13:
+    strcpy (encstr, "GEOSCOPE Muxed 16/3 bit gain/exp (val:13)");
+    break;
+  case 14:
+    strcpy (encstr, "GEOSCOPE Muxed 16/4 bit gain/exp (val:14)");
+    break;
+  case 15:
+    strcpy (encstr, "US National Network compression (val:15)");
+    break;
+  case 16:
+    strcpy (encstr, "CDSN 16 bit gain ranged (val:16)");
+    break;
+  case 17:
+    strcpy (encstr, "Graefenberg 16 bit gain ranged (val:17)");
+    break;
+  case 18:
+    strcpy (encstr, "IPG - Strasbourg 16 bit gain (val:18)");
+    break;
+  case 19:
+    strcpy (encstr, "STEIM 3 Compression (val:19)");
+    break;
+  case 30:
+    strcpy (encstr, "SRO Format (val:30)");
+    break;
+  case 31:
+    strcpy (encstr, "HGLP Format (val:31)");
+    break;
+  case 32:
+    strcpy (encstr, "DWWSSN Gain Ranged Format (val:32)");
+    break;
+  case 33:
+    strcpy (encstr, "RSTN 16 bit gain ranged (val:33)");
+    break;
+  default:
+    sprintf (encstr, "Unknown format code: (%d)", enc);
+  } /* end switch */
 
-}  /* End of encoding_hash() */
-
+} /* End of encoding_hash() */
 
 /***************************************************************************
  * host_latency:
@@ -694,24 +735,24 @@ encoding_hash (char enc, char *encstr)
 double
 host_latency (SLMSrecord *msr)
 {
-  double dsamprate = 0.0;       /* Nominal sampling rate */
-  double span = 0.0;            /* Time covered by the samples */
-  double epoch;                 /* Current epoch time */
-  double sepoch;                /* Epoch time of the record start time */
+  double dsamprate = 0.0; /* Nominal sampling rate */
+  double span      = 0.0; /* Time covered by the samples */
+  double epoch;           /* Current epoch time */
+  double sepoch;          /* Epoch time of the record start time */
   double latency = 0.0;
 
   sl_msr_dsamprate (msr, &dsamprate);
-    
+
   /* Calculate the time covered by the samples */
-  if ( dsamprate )
-    span = (double) msr->fsdh.num_samples * (1.0 / dsamprate);
-  
+  if (dsamprate)
+    span = (double)msr->fsdh.num_samples * (1.0 / dsamprate);
+
   /* Grab UTC time according to the system clock */
-  epoch = sl_dtime();
-  
+  epoch = sl_dtime ();
+
   /* Now calculate the latency */
-  sepoch = sl_msr_depochstime(msr);
+  sepoch  = sl_msr_depochstime (msr);
   latency = epoch - sepoch - span;
-  
+
   return latency;
-}  /* End of host_latency() */
+} /* End of host_latency() */

--- a/bin/rt/slink2orb/libslink/network.c
+++ b/bin/rt/slink2orb/libslink/network.c
@@ -4,14 +4,14 @@
  *
  * Network communication routines for SeedLink
  *
- * Written by Chad Trabant, 
+ * Written by Chad Trabant,
  *   ORFEUS/EC-Project MEREDIAN (previously)
  *   IRIS Data Management Center
  *
  * Originally based on the SeedLink interface of the modified Comserv in
  * SeisComP written by Andres Heinloo
  *
- * Version: 2010.075
+ * Version: 2016.288
  ***************************************************************************/
 
 #include <stdio.h>
@@ -21,11 +21,10 @@
 #include "libslink.h"
 
 /* Functions only used in this source file */
-int sl_sayhello (SLCD * slconn);
-int sl_batchmode (SLCD * slconn);
-int sl_negotiate_uni (SLCD * slconn);
-int sl_negotiate_multi (SLCD * slconn);
-
+int sl_sayhello (SLCD *slconn);
+int sl_batchmode (SLCD *slconn);
+int sl_negotiate_uni (SLCD *slconn);
+int sl_negotiate_multi (SLCD *slconn);
 
 /***************************************************************************
  * sl_configlink:
@@ -38,30 +37,29 @@ int sl_negotiate_multi (SLCD * slconn);
  * Returns -1 on errors, otherwise returns the link descriptor.
  ***************************************************************************/
 int
-sl_configlink (SLCD * slconn)
+sl_configlink (SLCD *slconn)
 {
   int ret = -1;
 
   if (slconn->multistation)
+  {
+    if (sl_checkversion (slconn, 2.5) >= 0)
     {
-      if (sl_checkversion (slconn, 2.5) >= 0)
-	{
-	  ret = sl_negotiate_multi (slconn);
-	}
-      else
-	{
-	  sl_log_r (slconn, 2, 0,
-		    "[%s] detected  SeedLink version (%.3f) does not support multi-station protocol\n",
-		    slconn->sladdr, slconn->protocol_ver);
-	  ret = -1;
-	}
+      ret = sl_negotiate_multi (slconn);
     }
+    else
+    {
+      sl_log_r (slconn, 2, 0,
+                "[%s] detected  SeedLink version (%.3f) does not support multi-station protocol\n",
+                slconn->sladdr, slconn->protocol_ver);
+      ret = -1;
+    }
+  }
   else
     ret = sl_negotiate_uni (slconn);
 
   return ret;
-}  /* End of sl_configlink() */
-
+} /* End of sl_configlink() */
 
 /***************************************************************************
  * sl_negotiate_uni:
@@ -79,194 +77,193 @@ sl_configlink (SLCD * slconn)
  * Returns -1 on errors, otherwise returns the link descriptor.
  ***************************************************************************/
 int
-sl_negotiate_uni (SLCD * slconn)
+sl_negotiate_uni (SLCD *slconn)
 {
-  int sellen = 0;
+  int sellen    = 0;
   int bytesread = 0;
-  int acceptsel = 0;		/* Count of accepted selectors */
+  int acceptsel = 0; /* Count of accepted selectors */
   char *selptr;
   char *extreply = 0;
   char *term1, *term2;
-  char sendstr[100];		/* A buffer for command strings */
-  char readbuf[100];		/* A buffer for responses */
+  char sendstr[100]; /* A buffer for command strings */
+  char readbuf[100]; /* A buffer for responses */
   SLstream *curstream;
-  
+
   /* Point to the stream chain */
   curstream = slconn->streams;
 
   selptr = curstream->selectors;
-  
+
   /* Send the selector(s) and check the response(s) */
   if (curstream->selectors != 0)
+  {
+    while (1)
     {
-      while (1)
-	{
-	  selptr += sellen;
-	  selptr += strspn (selptr, " ");
-	  sellen = strcspn (selptr, " ");
+      selptr += sellen;
+      selptr += strspn (selptr, " ");
+      sellen = strcspn (selptr, " ");
 
-	  if (sellen == 0)
-	    break;		/* end of while loop */
+      if (sellen == 0)
+        break; /* end of while loop */
 
-	  else if (sellen > SELSIZE)
-	    {
-	      sl_log_r (slconn, 2, 0, "[%s] invalid selector: %.*s\n", slconn->sladdr,
-			sellen, selptr);
-	      selptr += sellen;
-	    }
-	  else
-	    {
-	      
-	      /* Build SELECT command, send it and receive response */
-	      sprintf (sendstr, "SELECT %.*s\r", sellen, selptr);
-	      sl_log_r (slconn, 1, 2, "[%s] sending: SELECT %.*s\n", slconn->sladdr,
-			sellen, selptr);
-	      bytesread = sl_senddata (slconn, (void *) sendstr,
-				       strlen (sendstr), slconn->sladdr,
-				       readbuf, sizeof (readbuf));
-	      if (bytesread < 0)
-		{		/* Error from sl_senddata() */
-		  return -1;
-		}
-	      
-	      /* Search for 2nd "\r" indicating extended reply message present */
-	      extreply = 0;
-	      if ( (term1 = memchr (readbuf, '\r', bytesread)) )
-		{
-		  if ( (term2 = memchr (term1+1, '\r', bytesread-(readbuf-term1)-1)) )
-		    {
-		      *term2 = '\0';
-		      extreply = term1+1;
-		    }
-		}
-	      
-	      /* Check response to SELECT */
-	      if (!strncmp (readbuf, "OK\r", 3) && bytesread >= 4)
-		{
-		  sl_log_r (slconn, 1, 2, "[%s] selector %.*s is OK %s%s%s\n", slconn->sladdr,
-			    sellen, selptr, (extreply)?"{":"", (extreply)?extreply:"", (extreply)?"}":"");
-		  acceptsel++;
-		}
-	      else if (!strncmp (readbuf, "ERROR\r", 6) && bytesread >= 7)
-		{
-		  sl_log_r (slconn, 1, 2, "[%s] selector %.*s not accepted %s%s%s\n", slconn->sladdr,
-			    sellen, selptr, (extreply)?"{":"", (extreply)?extreply:"", (extreply)?"}":"");
-		}
-	      else
-		{
-		  sl_log_r (slconn, 2, 0,
-			    "[%s] invalid response to SELECT command: %.*s\n",
-			    slconn->sladdr, bytesread, readbuf);
-		  return -1;
-		}
-	    }
-	}
-      
-      /* Fail if none of the given selectors were accepted */
-      if (!acceptsel)
-	{
-	  sl_log_r (slconn, 2, 0, "[%s] no data stream selector(s) accepted\n",
-		    slconn->sladdr);
-	  return -1;
-	}
+      else if (sellen > SELSIZE)
+      {
+        sl_log_r (slconn, 2, 0, "[%s] invalid selector: %.*s\n", slconn->sladdr,
+                  sellen, selptr);
+        selptr += sellen;
+      }
       else
-	{
-	  sl_log_r (slconn, 1, 2, "[%s] %d selector(s) accepted\n",
-		    slconn->sladdr, acceptsel);
-	}
-    }				/* End of selector processing */
+      {
+
+        /* Build SELECT command, send it and receive response */
+        sprintf (sendstr, "SELECT %.*s\r", sellen, selptr);
+        sl_log_r (slconn, 1, 2, "[%s] sending: SELECT %.*s\n", slconn->sladdr,
+                  sellen, selptr);
+        bytesread = sl_senddata (slconn, (void *)sendstr,
+                                 strlen (sendstr), slconn->sladdr,
+                                 readbuf, sizeof (readbuf));
+        if (bytesread < 0)
+        { /* Error from sl_senddata() */
+          return -1;
+        }
+
+        /* Search for 2nd "\r" indicating extended reply message present */
+        extreply = 0;
+        if ((term1 = memchr (readbuf, '\r', bytesread)))
+        {
+          if ((term2 = memchr (term1 + 1, '\r', bytesread - (readbuf - term1) - 1)))
+          {
+            *term2   = '\0';
+            extreply = term1 + 1;
+          }
+        }
+
+        /* Check response to SELECT */
+        if (!strncmp (readbuf, "OK\r", 3) && bytesread >= 4)
+        {
+          sl_log_r (slconn, 1, 2, "[%s] selector %.*s is OK %s%s%s\n", slconn->sladdr,
+                    sellen, selptr, (extreply) ? "{" : "", (extreply) ? extreply : "", (extreply) ? "}" : "");
+          acceptsel++;
+        }
+        else if (!strncmp (readbuf, "ERROR\r", 6) && bytesread >= 7)
+        {
+          sl_log_r (slconn, 1, 2, "[%s] selector %.*s not accepted %s%s%s\n", slconn->sladdr,
+                    sellen, selptr, (extreply) ? "{" : "", (extreply) ? extreply : "", (extreply) ? "}" : "");
+        }
+        else
+        {
+          sl_log_r (slconn, 2, 0,
+                    "[%s] invalid response to SELECT command: %.*s\n",
+                    slconn->sladdr, bytesread, readbuf);
+          return -1;
+        }
+      }
+    }
+
+    /* Fail if none of the given selectors were accepted */
+    if (!acceptsel)
+    {
+      sl_log_r (slconn, 2, 0, "[%s] no data stream selector(s) accepted\n",
+                slconn->sladdr);
+      return -1;
+    }
+    else
+    {
+      sl_log_r (slconn, 1, 2, "[%s] %d selector(s) accepted\n",
+                slconn->sladdr, acceptsel);
+    }
+  } /* End of selector processing */
 
   /* Issue the DATA, FETCH or TIME action commands.  A specified start (and
      optionally, stop time) takes precedence over the resumption from any
      previous sequence number. */
   if (slconn->begin_time != NULL)
+  {
+    if (sl_checkversion (slconn, (float)2.92) >= 0)
     {
-      if (sl_checkversion (slconn, (float)2.92) >= 0)
-	{
-	  if (slconn->end_time == NULL)
-	    {
-	      sprintf (sendstr, "TIME %.25s\r", slconn->begin_time);
-	    }
-	  else
-	    {
-	      sprintf (sendstr, "TIME %.25s %.25s\r", slconn->begin_time,
-		       slconn->end_time);
-	    }
-	  sl_log_r (slconn, 1, 1, "[%s] requesting specified time window\n",
-		    slconn->sladdr);
-	}
+      if (slconn->end_time == NULL)
+      {
+        sprintf (sendstr, "TIME %.25s\r", slconn->begin_time);
+      }
       else
-	{
-	  sl_log_r (slconn, 2, 0,
-		    "[%s] detected SeedLink version (%.3f) does not support TIME windows\n",
-		    slconn->sladdr, slconn->protocol_ver);
-	}
+      {
+        sprintf (sendstr, "TIME %.25s %.25s\r", slconn->begin_time,
+                 slconn->end_time);
+      }
+      sl_log_r (slconn, 1, 1, "[%s] requesting specified time window\n",
+                slconn->sladdr);
     }
-  else if (curstream->seqnum != -1 && slconn->resume )
+    else
     {
-      char cmd[10];
-
-      if ( slconn->dialup )
-	{
-	  sprintf (cmd, "FETCH");
-	}
-      else
-	{
-	  sprintf (cmd, "DATA");
-	}
-
-      /* Append the last packet time if the feature is enabled and server is >= 2.93 */
-      if (slconn->lastpkttime &&
-	  sl_checkversion (slconn, (float)2.93) >= 0 &&
-	  strlen (curstream->timestamp))
-	{
-	  /* Increment sequence number by 1 */
-	  sprintf (sendstr, "%s %06X %.25s\r", cmd,
-		   (curstream->seqnum + 1) & 0xffffff, curstream->timestamp);
-
-	  sl_log_r (slconn, 1, 1, "[%s] resuming data from %06X (Dec %d) at %.25s\n",
-		    slconn->sladdr, (curstream->seqnum + 1) & 0xffffff,
-		    (curstream->seqnum + 1), curstream->timestamp);
-	}
-      else
-	{
-	  /* Increment sequence number by 1 */
-	  sprintf (sendstr, "%s %06X\r", cmd, (curstream->seqnum + 1) & 0xffffff);
-
-	  sl_log_r (slconn, 1, 1, "[%s] resuming data from %06X (Dec %d)\n",
-		    slconn->sladdr, (curstream->seqnum + 1) & 0xffffff,
-		    (curstream->seqnum + 1));
-	}
+      sl_log_r (slconn, 2, 0,
+                "[%s] detected SeedLink version (%.3f) does not support TIME windows\n",
+                slconn->sladdr, slconn->protocol_ver);
     }
+  }
+  else if (curstream->seqnum != -1 && slconn->resume)
+  {
+    char cmd[10];
+
+    if (slconn->dialup)
+    {
+      sprintf (cmd, "FETCH");
+    }
+    else
+    {
+      sprintf (cmd, "DATA");
+    }
+
+    /* Append the last packet time if the feature is enabled and server is >= 2.93 */
+    if (slconn->lastpkttime &&
+        sl_checkversion (slconn, (float)2.93) >= 0 &&
+        strlen (curstream->timestamp))
+    {
+      /* Increment sequence number by 1 */
+      sprintf (sendstr, "%s %06X %.25s\r", cmd,
+               (curstream->seqnum + 1) & 0xffffff, curstream->timestamp);
+
+      sl_log_r (slconn, 1, 1, "[%s] resuming data from %06X (Dec %d) at %.25s\n",
+                slconn->sladdr, (curstream->seqnum + 1) & 0xffffff,
+                (curstream->seqnum + 1), curstream->timestamp);
+    }
+    else
+    {
+      /* Increment sequence number by 1 */
+      sprintf (sendstr, "%s %06X\r", cmd, (curstream->seqnum + 1) & 0xffffff);
+
+      sl_log_r (slconn, 1, 1, "[%s] resuming data from %06X (Dec %d)\n",
+                slconn->sladdr, (curstream->seqnum + 1) & 0xffffff,
+                (curstream->seqnum + 1));
+    }
+  }
   else
+  {
+    if (slconn->dialup)
     {
-      if ( slconn->dialup )
-	{
-	  sprintf (sendstr, "FETCH\r");
-	}
-      else
-	{
-	  sprintf (sendstr, "DATA\r");
-	}
-
-      sl_log_r (slconn, 1, 1, "[%s] requesting next available data\n", slconn->sladdr);
+      sprintf (sendstr, "FETCH\r");
+    }
+    else
+    {
+      sprintf (sendstr, "DATA\r");
     }
 
-  if (sl_senddata (slconn, (void *) sendstr, strlen (sendstr),
-		   slconn->sladdr, (void *) NULL, 0) < 0)
-    {
-      sl_log_r (slconn, 2, 0, "[%s] error sending DATA/FETCH/TIME request\n", slconn->sladdr);
-      return -1;
-    }
+    sl_log_r (slconn, 1, 1, "[%s] requesting next available data\n", slconn->sladdr);
+  }
+
+  if (sl_senddata (slconn, (void *)sendstr, strlen (sendstr),
+                   slconn->sladdr, (void *)NULL, 0) < 0)
+  {
+    sl_log_r (slconn, 2, 0, "[%s] error sending DATA/FETCH/TIME request\n", slconn->sladdr);
+    return -1;
+  }
 
   return slconn->link;
-}  /* End of sl_negotiate_uni() */
-
+} /* End of sl_negotiate_uni() */
 
 /***************************************************************************
  * sl_negotiate_multi:
  *
- * Negotiate a SeedLink connection using multi-station mode and 
+ * Negotiate a SeedLink connection using multi-station mode and
  * issue the END action command.  This is compatible with SeedLink
  * Protocol version 3, multi-station mode.
  *
@@ -279,18 +276,18 @@ sl_negotiate_uni (SLCD * slconn)
  * Returns -1 on errors, otherwise returns the link descriptor.
  ***************************************************************************/
 int
-sl_negotiate_multi (SLCD * slconn)
+sl_negotiate_multi (SLCD *slconn)
 {
-  int sellen = 0;
+  int sellen    = 0;
   int bytesread = 0;
-  int acceptsta = 0;		/* Count of accepted stations */
-  int acceptsel = 0;		/* Count of accepted selectors */
+  int acceptsta = 0; /* Count of accepted stations */
+  int acceptsel = 0; /* Count of accepted selectors */
   char *selptr;
   char *term1, *term2;
   char *extreply = 0;
-  char sendstr[100];		/* A buffer for command strings */
-  char readbuf[100];		/* A buffer for responses */
-  char slring[12];		/* Keep track of the ring name */
+  char sendstr[100]; /* A buffer for command strings */
+  char readbuf[100]; /* A buffer for responses */
+  char slring[12];   /* Keep track of the ring name */
   SLstream *curstream;
 
   /* Point to the stream chain */
@@ -298,290 +295,289 @@ sl_negotiate_multi (SLCD * slconn)
 
   /* Loop through the stream chain */
   while (curstream != NULL)
+  {
+
+    /* A ring identifier */
+    snprintf (slring, sizeof (slring), "%s_%s",
+              curstream->net, curstream->sta);
+
+    /* Send the STATION command */
+    sprintf (sendstr, "STATION %s %s\r", curstream->sta, curstream->net);
+    sl_log_r (slconn, 1, 2, "[%s] sending: STATION %s %s\n",
+              slring, curstream->sta, curstream->net);
+    bytesread = sl_senddata (slconn, (void *)sendstr,
+                             strlen (sendstr), slring, readbuf,
+                             sizeof (readbuf));
+    if (bytesread < 0)
     {
-
-      /* A ring identifier */
-      snprintf (slring, sizeof (slring), "%s_%s",
-		curstream->net, curstream->sta);
-
-      /* Send the STATION command */
-      sprintf (sendstr, "STATION %s %s\r", curstream->sta, curstream->net);
-      sl_log_r (slconn, 1, 2, "[%s] sending: STATION %s %s\n",
-		slring, curstream->sta, curstream->net);
-      bytesread = sl_senddata (slconn, (void *) sendstr,
-			       strlen (sendstr), slring, readbuf,
-			       sizeof (readbuf));
-      if (bytesread < 0)
-	{
-	  return -1;
-	}
-      
-      /* Search for 2nd "\r" indicating extended reply message present */
-      extreply = 0;
-      if ( (term1 = memchr (readbuf, '\r', bytesread)) )
-	{
-	  if ( (term2 = memchr (term1+1, '\r', bytesread-(readbuf-term1)-1)) )
-	    {
-	      *term2 = '\0';
-	      extreply = term1+1;
-	    }
-	}
-      
-      /* Check the response */
-      if (!strncmp (readbuf, "OK\r", 3) && bytesread >= 4)
-	{
-	  sl_log_r (slconn, 1, 2, "[%s] station is OK %s%s%s\n", slring,
-		    (extreply)?"{":"", (extreply)?extreply:"", (extreply)?"}":"");
-	  acceptsta++;
-	}
-      else if (!strncmp (readbuf, "ERROR\r", 6) && bytesread >= 7)
-	{
-	  sl_log_r (slconn, 2, 0, "[%s] station not accepted %s%s%s\n", slring,
-		    (extreply)?"{":"", (extreply)?extreply:"", (extreply)?"}":"");
-	  /* Increment the loop control and skip to the next stream */
-	  curstream = curstream->next;
-	  continue;
-	}
-      else
-	{
-	  sl_log_r (slconn, 2, 0, "[%s] invalid response to STATION command: %.*s\n",
-		    slring, bytesread, readbuf);
-	  return -1;
-	}
-
-      selptr = curstream->selectors;
-      sellen = 0;
-
-      /* Send the selector(s) and check the response(s) */
-      if (curstream->selectors != 0)
-	{
-	  while (1)
-	    {
-	      selptr += sellen;
-	      selptr += strspn (selptr, " ");
-	      sellen = strcspn (selptr, " ");
-
-	      if (sellen == 0)
-		break;		/* end of while loop */
-
-	      else if (sellen > SELSIZE)
-		{
-		  sl_log_r (slconn, 2, 0, "[%s] invalid selector: %.*s\n",
-			    slring, sellen, selptr);
-		  selptr += sellen;
-		}
-	      else
-		{
-
-		  /* Build SELECT command, send it and receive response */
-		  sprintf (sendstr, "SELECT %.*s\r", sellen, selptr);
-		  sl_log_r (slconn, 1, 2, "[%s] sending: SELECT %.*s\n", slring, sellen,
-			    selptr);
-		  bytesread = sl_senddata (slconn, (void *) sendstr,
-					   strlen (sendstr), slring,
- 					   readbuf, sizeof (readbuf));
-		  if (bytesread < 0)
-		    {		/* Error from sl_senddata() */
-		      return -1;
-		    }
-		  
-		  /* Search for 2nd "\r" indicating extended reply message present */
-		  extreply = 0;
-		  if ( (term1 = memchr (readbuf, '\r', bytesread)) )
-		    {
-		      if ( (term2 = memchr (term1+1, '\r', bytesread-(readbuf-term1)-1)) )
-			{
-			  *term2 = '\0';
-			  extreply = term1+1;
-			}
-		    }
-		  
-		  /* Check response to SELECT */
-		  if (!strncmp (readbuf, "OK\r", 3) && bytesread >= 4)
-		    {
-		      sl_log_r (slconn, 1, 2, "[%s] selector %.*s is OK %s%s%s\n", slring,
-				sellen, selptr, (extreply)?"{":"", (extreply)?extreply:"", (extreply)?"}":"");
-		      acceptsel++;
-		    }
-		  else if (!strncmp (readbuf, "ERROR\r", 6) && bytesread >= 7)
-		    {
-		      sl_log_r (slconn, 2, 0, "[%s] selector %.*s not accepted %s%s%s\n", slring,
-				sellen, selptr, (extreply)?"{":"", (extreply)?extreply:"", (extreply)?"}":"");
-		    }
-		  else
-		    {
-		      sl_log_r (slconn, 2, 0,
-				"[%s] invalid response to SELECT command: %.*s\n",
-				slring, bytesread, readbuf);
-		      return -1;
-		    }
-		}
-	    }
-
-	  /* Fail if none of the given selectors were accepted */
-	  if (!acceptsel)
-	    {
-	      sl_log_r (slconn, 2, 0, "[%s] no data stream selector(s) accepted",
-			slring);
-	      return -1;
-	    }
-	  else
-	    {
-	      sl_log_r (slconn, 1, 2, "[%s] %d selector(s) accepted\n", slring,
-			acceptsel);
-	    }
-
-	  acceptsel = 0;	/* Reset the accepted selector count */
-
-	}			/* End of selector processing */
-
-      /* Issue the DATA, FETCH or TIME action commands.  A specified start (and
-	 optionally, stop time) takes precedence over the resumption from any
-	 previous sequence number. */
-      if (slconn->begin_time != NULL)
-	{
-	  if (sl_checkversion (slconn, (float)2.92) >= 0)
-	    {
-	      if (slconn->end_time == NULL)
-		{
-		  sprintf (sendstr, "TIME %.25s\r", slconn->begin_time);
-		}
-	      else
-		{
-		  sprintf (sendstr, "TIME %.25s %.25s\r", slconn->begin_time,
-			   slconn->end_time);
-		}
-	      sl_log_r (slconn, 1, 1, "[%s] requesting specified time window\n",
-			slring);
-	    }
-	  else
-	    {
-	      sl_log_r (slconn, 2, 0,
-			"[%s] detected SeedLink version (%.3f) does not support TIME windows\n",
-			slring, slconn->protocol_ver);
-	    }
-	}
-      else if (curstream->seqnum != -1 && slconn->resume )
-	{
-	  char cmd[10];
-	  
-	  if ( slconn->dialup )
-	    {
-	      sprintf (cmd, "FETCH");
-	    }
-	  else
-	    {
-	      sprintf (cmd, "DATA");
-	    }
-	  
-	  /* Append the last packet time if the feature is enabled and server is >= 2.93 */
-	  if (slconn->lastpkttime &&
-	      sl_checkversion (slconn, (float)2.93) >= 0 &&
-	      strlen (curstream->timestamp))
-	    {
-	      /* Increment sequence number by 1 */
-	      sprintf (sendstr, "%s %06X %.25s\r", cmd,
-		       (curstream->seqnum + 1) & 0xffffff, curstream->timestamp);
-
-	      sl_log_r (slconn, 1, 1, "[%s] resuming data from %06X (Dec %d) at %.25s\n",
-			slconn->sladdr, (curstream->seqnum + 1) & 0xffffff,
-			(curstream->seqnum + 1), curstream->timestamp);
-	    }	  
-	  else
-	    { /* Increment sequence number by 1 */
-	      sprintf (sendstr, "%s %06X\r", cmd,
-		       (curstream->seqnum + 1) & 0xffffff);
-
-	      sl_log_r (slconn, 1, 1, "[%s] resuming data from %06X (Dec %d)\n", slring,
-			(curstream->seqnum + 1) & 0xffffff,
-			(curstream->seqnum + 1));
-	    }
-	}
-      else
-	{
-	  if ( slconn->dialup )
-	    {
-	      sprintf (sendstr, "FETCH\r");
-	    }
-	  else
-	    {
-	      sprintf (sendstr, "DATA\r");
-	    }
-	  
-	  sl_log_r (slconn, 1, 1, "[%s] requesting next available data\n", slring);
-	}
-
-      /* Send the TIME/DATA/FETCH command and receive response */
-      bytesread = sl_senddata (slconn, (void *) sendstr,
-			       strlen (sendstr), slring,
-			       readbuf, sizeof (readbuf));
-      if (bytesread < 0)
-	{
-	  sl_log_r (slconn, 2, 0, "[%s] error with DATA/FETCH/TIME request\n", slring);
-	  return -1;
-	}
-      
-      /* Search for 2nd "\r" indicating extended reply message present */
-      extreply = 0;
-      if ( (term1 = memchr (readbuf, '\r', bytesread)) )
-	{
-	  if ( (term2 = memchr (term1+1, '\r', bytesread-(readbuf-term1)-1)) )
-	    {
-	      fprintf (stderr, "term2: '%s'\n", term2);
-
-	      *term2 = '\0';
-	      extreply = term1+1;
-	    }
-	}
-      
-      /* Check response to DATA/FETCH/TIME request */
-      if (!strncmp (readbuf, "OK\r", 3) && bytesread >= 4)
-	{
-	  sl_log_r (slconn, 1, 2, "[%s] DATA/FETCH/TIME command is OK %s%s%s\n", slring,
-		    (extreply)?"{":"", (extreply)?extreply:"", (extreply)?"}":"");
-	}
-      else if (!strncmp (readbuf, "ERROR\r", 6) && bytesread >= 7)
-	{
-	  sl_log_r (slconn, 2, 0, "[%s] DATA/FETCH/TIME command is not accepted %s%s%s\n", slring,
-		    (extreply)?"{":"", (extreply)?extreply:"", (extreply)?"}":"");
-	}
-      else
-	{
-	  sl_log_r (slconn, 2, 0, "[%s] invalid response to DATA/FETCH/TIME command: %.*s\n",
-		    slring, bytesread, readbuf);
-	  return -1;
-	}
-      
-      /* Point to the next stream */
-      curstream = curstream->next;
-
-    }  /* End of stream and selector config (end of stream chain). */
-  
-  /* Fail if no stations were accepted */
-  if (!acceptsta)
-    {
-      sl_log_r (slconn, 2, 0, "[%s] no station(s) accepted\n", slconn->sladdr);
       return -1;
     }
-  else
+
+    /* Search for 2nd "\r" indicating extended reply message present */
+    extreply = 0;
+    if ((term1 = memchr (readbuf, '\r', bytesread)))
     {
-      sl_log_r (slconn, 1, 1, "[%s] %d station(s) accepted\n",
-	      slconn->sladdr, acceptsta);
+      if ((term2 = memchr (term1 + 1, '\r', bytesread - (readbuf - term1) - 1)))
+      {
+        *term2   = '\0';
+        extreply = term1 + 1;
+      }
     }
+
+    /* Check the response */
+    if (!strncmp (readbuf, "OK\r", 3) && bytesread >= 4)
+    {
+      sl_log_r (slconn, 1, 2, "[%s] station is OK %s%s%s\n", slring,
+                (extreply) ? "{" : "", (extreply) ? extreply : "", (extreply) ? "}" : "");
+      acceptsta++;
+    }
+    else if (!strncmp (readbuf, "ERROR\r", 6) && bytesread >= 7)
+    {
+      sl_log_r (slconn, 2, 0, "[%s] station not accepted %s%s%s\n", slring,
+                (extreply) ? "{" : "", (extreply) ? extreply : "", (extreply) ? "}" : "");
+      /* Increment the loop control and skip to the next stream */
+      curstream = curstream->next;
+      continue;
+    }
+    else
+    {
+      sl_log_r (slconn, 2, 0, "[%s] invalid response to STATION command: %.*s\n",
+                slring, bytesread, readbuf);
+      return -1;
+    }
+
+    selptr = curstream->selectors;
+    sellen = 0;
+
+    /* Send the selector(s) and check the response(s) */
+    if (curstream->selectors != 0)
+    {
+      while (1)
+      {
+        selptr += sellen;
+        selptr += strspn (selptr, " ");
+        sellen = strcspn (selptr, " ");
+
+        if (sellen == 0)
+          break; /* end of while loop */
+
+        else if (sellen > SELSIZE)
+        {
+          sl_log_r (slconn, 2, 0, "[%s] invalid selector: %.*s\n",
+                    slring, sellen, selptr);
+          selptr += sellen;
+        }
+        else
+        {
+
+          /* Build SELECT command, send it and receive response */
+          sprintf (sendstr, "SELECT %.*s\r", sellen, selptr);
+          sl_log_r (slconn, 1, 2, "[%s] sending: SELECT %.*s\n", slring, sellen,
+                    selptr);
+          bytesread = sl_senddata (slconn, (void *)sendstr,
+                                   strlen (sendstr), slring,
+                                   readbuf, sizeof (readbuf));
+          if (bytesread < 0)
+          { /* Error from sl_senddata() */
+            return -1;
+          }
+
+          /* Search for 2nd "\r" indicating extended reply message present */
+          extreply = 0;
+          if ((term1 = memchr (readbuf, '\r', bytesread)))
+          {
+            if ((term2 = memchr (term1 + 1, '\r', bytesread - (readbuf - term1) - 1)))
+            {
+              *term2   = '\0';
+              extreply = term1 + 1;
+            }
+          }
+
+          /* Check response to SELECT */
+          if (!strncmp (readbuf, "OK\r", 3) && bytesread >= 4)
+          {
+            sl_log_r (slconn, 1, 2, "[%s] selector %.*s is OK %s%s%s\n", slring,
+                      sellen, selptr, (extreply) ? "{" : "", (extreply) ? extreply : "", (extreply) ? "}" : "");
+            acceptsel++;
+          }
+          else if (!strncmp (readbuf, "ERROR\r", 6) && bytesread >= 7)
+          {
+            sl_log_r (slconn, 2, 0, "[%s] selector %.*s not accepted %s%s%s\n", slring,
+                      sellen, selptr, (extreply) ? "{" : "", (extreply) ? extreply : "", (extreply) ? "}" : "");
+          }
+          else
+          {
+            sl_log_r (slconn, 2, 0,
+                      "[%s] invalid response to SELECT command: %.*s\n",
+                      slring, bytesread, readbuf);
+            return -1;
+          }
+        }
+      }
+
+      /* Fail if none of the given selectors were accepted */
+      if (!acceptsel)
+      {
+        sl_log_r (slconn, 2, 0, "[%s] no data stream selector(s) accepted",
+                  slring);
+        return -1;
+      }
+      else
+      {
+        sl_log_r (slconn, 1, 2, "[%s] %d selector(s) accepted\n", slring,
+                  acceptsel);
+      }
+
+      acceptsel = 0; /* Reset the accepted selector count */
+
+    } /* End of selector processing */
+
+    /* Issue the DATA, FETCH or TIME action commands.  A specified start (and
+	 optionally, stop time) takes precedence over the resumption from any
+	 previous sequence number. */
+    if (slconn->begin_time != NULL)
+    {
+      if (sl_checkversion (slconn, (float)2.92) >= 0)
+      {
+        if (slconn->end_time == NULL)
+        {
+          sprintf (sendstr, "TIME %.25s\r", slconn->begin_time);
+        }
+        else
+        {
+          sprintf (sendstr, "TIME %.25s %.25s\r", slconn->begin_time,
+                   slconn->end_time);
+        }
+        sl_log_r (slconn, 1, 1, "[%s] requesting specified time window\n",
+                  slring);
+      }
+      else
+      {
+        sl_log_r (slconn, 2, 0,
+                  "[%s] detected SeedLink version (%.3f) does not support TIME windows\n",
+                  slring, slconn->protocol_ver);
+      }
+    }
+    else if (curstream->seqnum != -1 && slconn->resume)
+    {
+      char cmd[10];
+
+      if (slconn->dialup)
+      {
+        sprintf (cmd, "FETCH");
+      }
+      else
+      {
+        sprintf (cmd, "DATA");
+      }
+
+      /* Append the last packet time if the feature is enabled and server is >= 2.93 */
+      if (slconn->lastpkttime &&
+          sl_checkversion (slconn, (float)2.93) >= 0 &&
+          strlen (curstream->timestamp))
+      {
+        /* Increment sequence number by 1 */
+        sprintf (sendstr, "%s %06X %.25s\r", cmd,
+                 (curstream->seqnum + 1) & 0xffffff, curstream->timestamp);
+
+        sl_log_r (slconn, 1, 1, "[%s] resuming data from %06X (Dec %d) at %.25s\n",
+                  slconn->sladdr, (curstream->seqnum + 1) & 0xffffff,
+                  (curstream->seqnum + 1), curstream->timestamp);
+      }
+      else
+      { /* Increment sequence number by 1 */
+        sprintf (sendstr, "%s %06X\r", cmd,
+                 (curstream->seqnum + 1) & 0xffffff);
+
+        sl_log_r (slconn, 1, 1, "[%s] resuming data from %06X (Dec %d)\n", slring,
+                  (curstream->seqnum + 1) & 0xffffff,
+                  (curstream->seqnum + 1));
+      }
+    }
+    else
+    {
+      if (slconn->dialup)
+      {
+        sprintf (sendstr, "FETCH\r");
+      }
+      else
+      {
+        sprintf (sendstr, "DATA\r");
+      }
+
+      sl_log_r (slconn, 1, 1, "[%s] requesting next available data\n", slring);
+    }
+
+    /* Send the TIME/DATA/FETCH command and receive response */
+    bytesread = sl_senddata (slconn, (void *)sendstr,
+                             strlen (sendstr), slring,
+                             readbuf, sizeof (readbuf));
+    if (bytesread < 0)
+    {
+      sl_log_r (slconn, 2, 0, "[%s] error with DATA/FETCH/TIME request\n", slring);
+      return -1;
+    }
+
+    /* Search for 2nd "\r" indicating extended reply message present */
+    extreply = 0;
+    if ((term1 = memchr (readbuf, '\r', bytesread)))
+    {
+      if ((term2 = memchr (term1 + 1, '\r', bytesread - (readbuf - term1) - 1)))
+      {
+        fprintf (stderr, "term2: '%s'\n", term2);
+
+        *term2   = '\0';
+        extreply = term1 + 1;
+      }
+    }
+
+    /* Check response to DATA/FETCH/TIME request */
+    if (!strncmp (readbuf, "OK\r", 3) && bytesread >= 4)
+    {
+      sl_log_r (slconn, 1, 2, "[%s] DATA/FETCH/TIME command is OK %s%s%s\n", slring,
+                (extreply) ? "{" : "", (extreply) ? extreply : "", (extreply) ? "}" : "");
+    }
+    else if (!strncmp (readbuf, "ERROR\r", 6) && bytesread >= 7)
+    {
+      sl_log_r (slconn, 2, 0, "[%s] DATA/FETCH/TIME command is not accepted %s%s%s\n", slring,
+                (extreply) ? "{" : "", (extreply) ? extreply : "", (extreply) ? "}" : "");
+    }
+    else
+    {
+      sl_log_r (slconn, 2, 0, "[%s] invalid response to DATA/FETCH/TIME command: %.*s\n",
+                slring, bytesread, readbuf);
+      return -1;
+    }
+
+    /* Point to the next stream */
+    curstream = curstream->next;
+
+  } /* End of stream and selector config (end of stream chain). */
+
+  /* Fail if no stations were accepted */
+  if (!acceptsta)
+  {
+    sl_log_r (slconn, 2, 0, "[%s] no station(s) accepted\n", slconn->sladdr);
+    return -1;
+  }
+  else
+  {
+    sl_log_r (slconn, 1, 1, "[%s] %d station(s) accepted\n",
+              slconn->sladdr, acceptsta);
+  }
 
   /* Issue END action command */
   sprintf (sendstr, "END\r");
   sl_log_r (slconn, 1, 2, "[%s] sending: END\n", slconn->sladdr);
-  if (sl_senddata (slconn, (void *) sendstr, strlen (sendstr),
-		   slconn->sladdr, (void *) NULL, 0) < 0)
-    {
-      sl_log_r (slconn, 2, 0, "[%s] error sending END command\n", slconn->sladdr);
-      return -1;
-    }
+  if (sl_senddata (slconn, (void *)sendstr, strlen (sendstr),
+                   slconn->sladdr, (void *)NULL, 0) < 0)
+  {
+    sl_log_r (slconn, 2, 0, "[%s] error sending END command\n", slconn->sladdr);
+    return -1;
+  }
 
   return slconn->link;
-}  /* End of sl_negotiate_multi() */
-
+} /* End of sl_negotiate_multi() */
 
 /***************************************************************************
  * sl_send_info:
@@ -593,35 +589,34 @@ sl_negotiate_multi (SLCD * slconn)
  * Returns -1 on errors, otherwise the socket descriptor.
  ***************************************************************************/
 int
-sl_send_info (SLCD * slconn, const char * info_level, int verbose)
+sl_send_info (SLCD *slconn, const char *info_level, int verbose)
 {
-  char sendstr[40];		/* A buffer for command strings */
+  char sendstr[40]; /* A buffer for command strings */
 
   if (sl_checkversion (slconn, (float)2.92) >= 0)
-    {
-      sprintf (sendstr, "INFO %.15s\r", info_level);
+  {
+    sprintf (sendstr, "INFO %.15s\r", info_level);
 
-      sl_log_r (slconn, 1, verbose, "[%s] requesting INFO level %s\n",
-		slconn->sladdr, info_level);
+    sl_log_r (slconn, 1, verbose, "[%s] requesting INFO level %s\n",
+              slconn->sladdr, info_level);
 
-      if (sl_senddata (slconn, (void *) sendstr, strlen (sendstr),
-		       slconn->sladdr, (void *) NULL, 0) < 0)
-	{
-	  sl_log_r (slconn, 2, 0, "[%s] error sending INFO request\n", slconn->sladdr);
-	  return -1;
-	}
-    }
-  else
+    if (sl_senddata (slconn, (void *)sendstr, strlen (sendstr),
+                     slconn->sladdr, (void *)NULL, 0) < 0)
     {
-      sl_log_r (slconn, 2, 0,
-		"[%s] detected SeedLink version (%.3f) does not support INFO requests\n",
-		slconn->sladdr, slconn->protocol_ver);   
+      sl_log_r (slconn, 2, 0, "[%s] error sending INFO request\n", slconn->sladdr);
       return -1;
     }
+  }
+  else
+  {
+    sl_log_r (slconn, 2, 0,
+              "[%s] detected SeedLink version (%.3f) does not support INFO requests\n",
+              slconn->sladdr, slconn->protocol_ver);
+    return -1;
+  }
 
   return slconn->link;
-}  /* End of sl_send_info() */
-
+} /* End of sl_send_info() */
 
 /***************************************************************************
  * sl_connect:
@@ -645,10 +640,10 @@ sl_send_info (SLCD * slconn, const char * info_level, int verbose)
  *
  * Returns -1 on errors otherwise the socket descriptor created.
  ***************************************************************************/
-int
-sl_connect (SLCD * slconn, int sayhello)
+SOCKET
+sl_connect (SLCD *slconn, int sayhello)
 {
-  int sock;
+  SOCKET sock;
   int on = 1;
   int sockstat;
   long int nport;
@@ -658,133 +653,132 @@ sl_connect (SLCD * slconn, int sayhello)
   size_t addrlen;
   struct sockaddr addr;
 
-  if ( slp_sockstartup() ) {
+  if (slp_sockstartup ())
+  {
     sl_log_r (slconn, 2, 0, "could not initialize network sockets\n");
     return -1;
   }
-  
+
   /* Check server address string and use defaults if needed:
    * If only ':' is specified neither host nor port specified
    * If no ':' is included no port was specified
    * If ':' is the first character no host was specified
    */
-  if ( ! strcmp (slconn->sladdr, ":") )
+  if (!strcmp (slconn->sladdr, ":"))
+  {
+    strcpy (nodename, "localhost");
+    strcpy (nodeport, "18000");
+  }
+  else if ((ptr = strchr (slconn->sladdr, ':')) == NULL)
+  {
+    strncpy (nodename, slconn->sladdr, sizeof (nodename));
+    strcpy (nodeport, "18000");
+  }
+  else
+  {
+    if (ptr == slconn->sladdr)
     {
       strcpy (nodename, "localhost");
-      strcpy (nodeport, "18000");
     }
-  else if ((ptr = strchr (slconn->sladdr, ':')) == NULL)
+    else
     {
-      strncpy (nodename, slconn->sladdr, sizeof(nodename));
-      strcpy (nodeport, "18000");
+      strncpy (nodename, slconn->sladdr, (ptr - slconn->sladdr));
+      nodename[(ptr - slconn->sladdr)] = '\0';
     }
-  else
-    {
-      if ( ptr == slconn->sladdr )
-	{
-	  strcpy (nodename, "localhost");
-	}
-      else
-	{
-	  strncpy (nodename, slconn->sladdr, (ptr - slconn->sladdr));
-	  nodename[(ptr - slconn->sladdr)] = '\0';
-	}
-      
-      strcpy (nodeport, ptr+1);
 
-      /* Sanity test the port number */
-      nport = strtoul (nodeport, &tail, 10);
-      if ( *tail || (nport <= 0 || nport > 0xffff) )
-	{
-	  sl_log_r (slconn, 2, 0, "server port specified incorrectly\n");
-	  slconn->terminate = 1;
-	  return -1;
-	}
-    }
-  
-  if ( slp_getaddrinfo (nodename, nodeport, &addr, &addrlen) )
+    strcpy (nodeport, ptr + 1);
+
+    /* Sanity test the port number */
+    nport = strtoul (nodeport, &tail, 10);
+    if (*tail || (nport <= 0 || nport > 0xffff))
     {
-      sl_log_r (slconn, 2, 0, "cannot resolve hostname %s\n", nodename );
+      sl_log_r (slconn, 2, 0, "server port specified incorrectly\n");
+      slconn->terminate = 1;
       return -1;
     }
+  }
+
+  if (slp_getaddrinfo (nodename, nodeport, &addr, &addrlen))
+  {
+    sl_log_r (slconn, 2, 0, "cannot resolve hostname %s\n", nodename);
+    return -1;
+  }
 
   if ((sock = socket (PF_INET, SOCK_STREAM, 0)) < 0)
-    {
-      sl_log_r (slconn, 2, 0, "[%s] socket(): %s\n", slconn->sladdr, slp_strerror ());
-      slp_sockclose (sock);
-      return -1;
-    }
+  {
+    sl_log_r (slconn, 2, 0, "[%s] socket(): %s\n", slconn->sladdr, slp_strerror ());
+    slp_sockclose (sock);
+    return -1;
+  }
 
   /* Set non-blocking IO */
-  if ( slp_socknoblock(sock) )
-    {
-      sl_log_r (slconn, 2, 0, "Error setting socket to non-blocking\n");
-    }
+  if (slp_socknoblock (sock))
+  {
+    sl_log_r (slconn, 2, 0, "Error setting socket to non-blocking\n");
+  }
 
-  if ( (slp_sockconnect (sock, (struct sockaddr *) &addr, addrlen)) )
-    {
-      sl_log_r (slconn, 2, 0, "[%s] connect(): %s\n", slconn->sladdr, slp_strerror ());
-      slp_sockclose (sock);
-      return -1;
-    }
-  
+  if ((slp_sockconnect (sock, (struct sockaddr *)&addr, addrlen)))
+  {
+    sl_log_r (slconn, 2, 0, "[%s] connect(): %s\n", slconn->sladdr, slp_strerror ());
+    slp_sockclose (sock);
+    return -1;
+  }
+
   /* Wait up to 10 seconds for the socket to be connected */
   if ((sockstat = sl_checksock (sock, 10, 0)) <= 0)
+  {
+    if (sockstat < 0)
+    { /* select() returned error */
+      sl_log_r (slconn, 2, 1, "[%s] socket connect error\n", slconn->sladdr);
+    }
+    else
+    { /* socket time-out */
+      sl_log_r (slconn, 2, 1, "[%s] socket connect time-out (10s)\n",
+                slconn->sladdr);
+    }
+
+    slp_sockclose (sock);
+    return -1;
+  }
+  else if (!slconn->terminate)
+  { /* socket connected */
+    sl_log_r (slconn, 1, 1, "[%s] network socket opened\n", slconn->sladdr);
+
+    /* Set the SO_KEEPALIVE socket option, although not really useful */
+    if (setsockopt (sock, SOL_SOCKET, SO_KEEPALIVE, (char *)&on, sizeof (on)) < 0)
+      sl_log_r (slconn, 1, 1, "[%s] cannot set SO_KEEPALIVE socket option\n",
+                slconn->sladdr);
+
+    slconn->link = sock;
+
+    if (slconn->batchmode)
+      slconn->batchmode = 1;
+
+    /* Everything should be connected, say hello if requested */
+    if (sayhello)
     {
-      if (sockstat < 0)
-	{			/* select() returned error */
-	  sl_log_r (slconn, 2, 1, "[%s] socket connect error\n", slconn->sladdr);
-	}
-      else
-	{			/* socket time-out */
-	  sl_log_r (slconn, 2, 1, "[%s] socket connect time-out (10s)\n",
-		    slconn->sladdr);
-	}
-
-      slp_sockclose (sock);
-      return -1;
+      if (sl_sayhello (slconn) == -1)
+      {
+        slp_sockclose (sock);
+        return -1;
+      }
     }
-  else if ( ! slconn->terminate )
-    {				/* socket connected */
-      sl_log_r (slconn, 1, 1, "[%s] network socket opened\n", slconn->sladdr);
-      
-      /* Set the SO_KEEPALIVE socket option, although not really useful */
-      if (setsockopt
-	  (sock, SOL_SOCKET, SO_KEEPALIVE, (char *) &on, sizeof (on)) < 0)
-	sl_log_r (slconn, 1, 1, "[%s] cannot set SO_KEEPALIVE socket option\n",
-		  slconn->sladdr);
-      
-      slconn->link = sock;
 
-      if ( slconn->batchmode )
-	  slconn->batchmode = 1;
-      
-      /* Everything should be connected, say hello if requested */
-      if ( sayhello )
-	{
-	  if (sl_sayhello (slconn) == -1)
-	    {
-	      slp_sockclose (sock);
-	      return -1;
-	    }
-	}
-      
-      /* Try to enter batch mode if requested */
-      if ( slconn->batchmode )
-        {
-          if (sl_batchmode (slconn) == -1)
-	    {
-	      slp_sockclose (sock);
-	      return -1;
-	    }
-	}
-      
-      return sock;
+    /* Try to enter batch mode if requested */
+    if (slconn->batchmode)
+    {
+      if (sl_batchmode (slconn) == -1)
+      {
+        slp_sockclose (sock);
+        return -1;
+      }
     }
-  
+
+    return sock;
+  }
+
   return -1;
-}  /* End of sl_connect() */
-
+} /* End of sl_connect() */
 
 /***************************************************************************
  * sl_disconnect:
@@ -794,19 +788,18 @@ sl_connect (SLCD * slconn, int sayhello)
  * Returns -1, historically used to set the old descriptor
  ***************************************************************************/
 int
-sl_disconnect (SLCD * slconn)
+sl_disconnect (SLCD *slconn)
 {
   if (slconn->link != -1)
-    {
-      slp_sockclose (slconn->link);
-      slconn->link = -1;
-      
-      sl_log_r (slconn, 1, 1, "[%s] network socket closed\n", slconn->sladdr);
-    }
-  
-  return -1;
-}  /* End of sl_disconnect() */
+  {
+    slp_sockclose (slconn->link);
+    slconn->link = -1;
 
+    sl_log_r (slconn, 1, 1, "[%s] network socket closed\n", slconn->sladdr);
+  }
+
+  return -1;
+} /* End of sl_disconnect() */
 
 /***************************************************************************
  * sl_sayhello:
@@ -819,178 +812,178 @@ sl_disconnect (SLCD * slconn)
  * Returns -1 on errors, 0 on success.
  ***************************************************************************/
 int
-sl_sayhello (SLCD * slconn)
+sl_sayhello (SLCD *slconn)
 {
-  int ret = 0;
+  int ret     = 0;
   int servcnt = 0;
   int sitecnt = 0;
-  char sendstr[100];		/* A buffer for command strings */
-  char servstr[200];		/* The remote server ident */
-  char sitestr[100];		/* The site/data center ident */
-  char servid[100];		/* Server ID string, i.e. 'SeedLink' */
-  char *capptr;                 /* Pointer to capabilities flags */  
-  char capflag = 0;             /* Capabilities are supported by server */
+  char sendstr[100]; /* A buffer for command strings */
+  char servstr[200]; /* The remote server ident */
+  char sitestr[100]; /* The site/data center ident */
+  char servid[100];  /* Server ID string, i.e. 'SeedLink' */
+  char *capptr;      /* Pointer to capabilities flags */
+  char capflag = 0;  /* Capabilities are supported by server */
 
   /* Send HELLO */
   sprintf (sendstr, "HELLO\r");
   sl_log_r (slconn, 1, 2, "[%s] sending: %s\n", slconn->sladdr, sendstr);
-  sl_senddata (slconn, (void *) sendstr, strlen (sendstr), slconn->sladdr,
-	       NULL, 0);
-  
+  sl_senddata (slconn, (void *)sendstr, strlen (sendstr), slconn->sladdr,
+               NULL, 0);
+
   /* Recv the two lines of response: server ID and site installation ID */
-  if ( sl_recvresp (slconn, (void *) servstr, (size_t) sizeof (servstr),
-		    sendstr, slconn->sladdr) < 0 )
-    {
-      return -1;
-    }
-  
-  if ( sl_recvresp (slconn, (void *) sitestr, (size_t) sizeof (sitestr),
-		    sendstr, slconn->sladdr) < 0 )
-    {
-      return -1;
-    }
-  
+  if (sl_recvresp (slconn, (void *)servstr, (size_t)sizeof (servstr),
+                   sendstr, slconn->sladdr) < 0)
+  {
+    return -1;
+  }
+
+  if (sl_recvresp (slconn, (void *)sitestr, (size_t)sizeof (sitestr),
+                   sendstr, slconn->sladdr) < 0)
+  {
+    return -1;
+  }
+
   /* Terminate on first "\r" character or at one character before end of buffer */
   servcnt = strcspn (servstr, "\r");
-  if ( servcnt > (sizeof(servstr)-2) )
-    {
-      servcnt = (sizeof(servstr)-2);
-    }
+  if (servcnt > (sizeof (servstr) - 2))
+  {
+    servcnt = (sizeof (servstr) - 2);
+  }
   servstr[servcnt] = '\0';
-  
+
   sitecnt = strcspn (sitestr, "\r");
-  if ( sitecnt > (sizeof(sitestr)-2) )
-    {
-      sitecnt = (sizeof(sitestr)-2);
-    }
+  if (sitecnt > (sizeof (sitestr) - 2))
+  {
+    sitecnt = (sizeof (sitestr) - 2);
+  }
   sitestr[sitecnt] = '\0';
-  
+
   /* Search for capabilities flags in server ID by looking for "::"
    * The expected format of the complete server ID is:
    * "seedlink v#.# <optional text> <:: optional capability flags>"
    */
   capptr = strstr (servstr, "::");
-  if ( capptr )
-    {
-      /* Truncate server ID portion of string */
-      *capptr = '\0';
+  if (capptr)
+  {
+    /* Truncate server ID portion of string */
+    *capptr = '\0';
 
-      /* Move pointer to beginning of flags */
-      capptr += 2;
-      
-      /* Move capptr up to first non-space character */
-      while ( *capptr == ' ' )
-	capptr++;
-    }
-  
+    /* Move pointer to beginning of flags */
+    capptr += 2;
+
+    /* Move capptr up to first non-space character */
+    while (*capptr == ' ')
+      capptr++;
+  }
+
   /* Report received IDs */
   sl_log_r (slconn, 1, 1, "[%s] connected to: %s\n", slconn->sladdr, servstr);
-  if ( capptr )
+  if (capptr)
     sl_log_r (slconn, 1, 1, "[%s] capabilities: %s\n", slconn->sladdr, capptr);
   sl_log_r (slconn, 1, 1, "[%s] organization: %s\n", slconn->sladdr, sitestr);
-  
+
   /* Parse old-school server ID and version from the returned string.
    * The expected format at this point is:
    * "seedlink v#.# <optional text>"
    * where 'seedlink' is case insensitive and '#.#' is the server/protocol version.
    */
   /* Add a space to the end to allowing parsing when the optionals are not present */
-  servstr[servcnt] = ' '; servstr[servcnt+1] = '\0';
-  ret = sscanf (servstr, "%s v%f ", &servid[0], &slconn->protocol_ver);
-  
-  if ( ret != 2 || strncasecmp (servid, "SEEDLINK", 8) )
-    {
-      sl_log_r (slconn, 1, 1,
-                "[%s] unrecognized server version, assuming minimum functionality\n",
-                slconn->sladdr);
-      slconn->protocol_ver = 0.0;
-    }
-  
+  servstr[servcnt]     = ' ';
+  servstr[servcnt + 1] = '\0';
+  ret                  = sscanf (servstr, "%s v%f ", &servid[0], &slconn->protocol_ver);
+
+  if (ret != 2 || strncasecmp (servid, "SEEDLINK", 8))
+  {
+    sl_log_r (slconn, 1, 1,
+              "[%s] unrecognized server version, assuming minimum functionality\n",
+              slconn->sladdr);
+    slconn->protocol_ver = 0.0;
+  }
+
   /* Check capabilities flags */
-  if ( capptr )
+  if (capptr)
+  {
+    char *tptr;
+
+    /* Parse protocol version flag: "SLPROTO:<#.#>" if present */
+    if ((tptr = strstr (capptr, "SLPROTO")))
     {
-      char *tptr;
-      
-      /* Parse protocol version flag: "SLPROTO:<#.#>" if present */
-      if ( (tptr = strstr(capptr, "SLPROTO")) )
-	{
-	  /* This protocol specification overrides that from earlier in the server ID */
-	  ret = sscanf (tptr, "SLPROTO:%f", &slconn->protocol_ver);
-	  
-	  if ( ret != 1 )
-	    sl_log_r (slconn, 1, 1,
-		      "[%s] could not parse protocol version from SLPROTO flag: %s\n",
-		      slconn->sladdr, tptr);
-	}
-      
-      /* Check for CAPABILITIES command support */
-      if ( strstr(capptr, "CAP") )
-	capflag = 1;
+      /* This protocol specification overrides that from earlier in the server ID */
+      ret = sscanf (tptr, "SLPROTO:%f", &slconn->protocol_ver);
+
+      if (ret != 1)
+        sl_log_r (slconn, 1, 1,
+                  "[%s] could not parse protocol version from SLPROTO flag: %s\n",
+                  slconn->sladdr, tptr);
     }
-  
+
+    /* Check for CAPABILITIES command support */
+    if (strstr (capptr, "CAP"))
+      capflag = 1;
+  }
+
   /* Send CAPABILITIES flags if supported by server */
-  if ( capflag )
-    {
-      int bytesread = 0;
-      char readbuf[100];
-      
-      char *term1, *term2;
-      char *extreply = 0;
-      
-      /* Current capabilities:
+  if (capflag)
+  {
+    int bytesread = 0;
+    char readbuf[100];
+
+    char *term1, *term2;
+    char *extreply = 0;
+
+    /* Current capabilities:
        *   SLPROTO:3.1 = SeedLink protocol version
        *   CAP         = CAPABILITIES command support
        *   EXTREPLY    = Extended reply message handling
        *   NSWILDCARD  = Network and station code wildcard support
        *   BATCH       = BATCH command mode support
        */
-      sprintf (sendstr, "CAPABILITIES SLPROTO:3.1 CAP EXTREPLY NSWILDCARD BATCH\r");
-      
-      /* Send CAPABILITIES and recv response */
-      sl_log_r (slconn, 1, 2, "[%s] sending: %s\n", slconn->sladdr, sendstr);
-      bytesread = sl_senddata (slconn, (void *) sendstr, strlen (sendstr), slconn->sladdr,
-			       readbuf, sizeof (readbuf));
-      
-      if ( bytesread < 0 )
-	{		/* Error from sl_senddata() */
-	  return -1;
-	}
-      
-      /* Search for 2nd "\r" indicating extended reply message present */
-      extreply = 0;
-      if ( (term1 = memchr (readbuf, '\r', bytesread)) )
-	{
-	  if ( (term2 = memchr (term1+1, '\r', bytesread-(readbuf-term1)-1)) )
-	    {
-	      *term2 = '\0';
-	      extreply = term1+1;
-	    }
-	}
-      
-      /* Check response to CAPABILITIES */
-      if (!strncmp (readbuf, "OK\r", 3) && bytesread >= 4)
-	{
-	  sl_log_r (slconn, 1, 2, "[%s] capabilities OK %s%s%s\n", slconn->sladdr,
-		    (extreply)?"{":"", (extreply)?extreply:"", (extreply)?"}":"");
-	}
-      else if (!strncmp (readbuf, "ERROR\r", 6) && bytesread >= 7)
-	{
-	  sl_log_r (slconn, 1, 2, "[%s] CAPABILITIES not accepted %s%s%s\n", slconn->sladdr,
-		    (extreply)?"{":"", (extreply)?extreply:"", (extreply)?"}":"");	  
-	  return -1;
-	}
-      else
-	{
-	  sl_log_r (slconn, 2, 0,
-		    "[%s] invalid response to CAPABILITIES command: %.*s\n",
-		    slconn->sladdr, bytesread, readbuf);
-	  return -1;
-	}
-    }
-  
-  return 0;
-}  /* End of sl_sayhello() */
+    sprintf (sendstr, "CAPABILITIES SLPROTO:3.1 CAP EXTREPLY NSWILDCARD BATCH\r");
 
+    /* Send CAPABILITIES and recv response */
+    sl_log_r (slconn, 1, 2, "[%s] sending: %s\n", slconn->sladdr, sendstr);
+    bytesread = sl_senddata (slconn, (void *)sendstr, strlen (sendstr), slconn->sladdr,
+                             readbuf, sizeof (readbuf));
+
+    if (bytesread < 0)
+    { /* Error from sl_senddata() */
+      return -1;
+    }
+
+    /* Search for 2nd "\r" indicating extended reply message present */
+    extreply = 0;
+    if ((term1 = memchr (readbuf, '\r', bytesread)))
+    {
+      if ((term2 = memchr (term1 + 1, '\r', bytesread - (readbuf - term1) - 1)))
+      {
+        *term2   = '\0';
+        extreply = term1 + 1;
+      }
+    }
+
+    /* Check response to CAPABILITIES */
+    if (!strncmp (readbuf, "OK\r", 3) && bytesread >= 4)
+    {
+      sl_log_r (slconn, 1, 2, "[%s] capabilities OK %s%s%s\n", slconn->sladdr,
+                (extreply) ? "{" : "", (extreply) ? extreply : "", (extreply) ? "}" : "");
+    }
+    else if (!strncmp (readbuf, "ERROR\r", 6) && bytesread >= 7)
+    {
+      sl_log_r (slconn, 1, 2, "[%s] CAPABILITIES not accepted %s%s%s\n", slconn->sladdr,
+                (extreply) ? "{" : "", (extreply) ? extreply : "", (extreply) ? "}" : "");
+      return -1;
+    }
+    else
+    {
+      sl_log_r (slconn, 2, 0,
+                "[%s] invalid response to CAPABILITIES command: %.*s\n",
+                slconn->sladdr, bytesread, readbuf);
+      return -1;
+    }
+  }
+
+  return 0;
+} /* End of sl_sayhello() */
 
 /***************************************************************************
  * sl_batchmode:
@@ -1003,55 +996,54 @@ sl_sayhello (SLCD * slconn)
  * Sets slconn->batchmode accordingly.
  ***************************************************************************/
 int
-sl_batchmode (SLCD * slconn)
+sl_batchmode (SLCD *slconn)
 {
-  char sendstr[100];    /* A buffer for command strings */
-  char readbuf[100];    /* A buffer for server reply */
+  char sendstr[100]; /* A buffer for command strings */
+  char readbuf[100]; /* A buffer for server reply */
   int bytesread = 0;
-  
-  if ( ! slconn )
+
+  if (!slconn)
     return -1;
-  
+
   if (sl_checkversion (slconn, 3.1) < 0)
-    {
-      sl_log_r (slconn, 2, 0,
-		"[%s] detected SeedLink version (%.3f) does not support the BATCH command\n",
-		slconn->sladdr, slconn->protocol_ver);
-      return -1;
-    }
-  
+  {
+    sl_log_r (slconn, 2, 0,
+              "[%s] detected SeedLink version (%.3f) does not support the BATCH command\n",
+              slconn->sladdr, slconn->protocol_ver);
+    return -1;
+  }
+
   /* Send BATCH and recv response */
   sprintf (sendstr, "BATCH\r");
   sl_log_r (slconn, 1, 2, "[%s] sending: %s\n", slconn->sladdr, sendstr);
-  bytesread = sl_senddata (slconn, (void *) sendstr, strlen (sendstr), slconn->sladdr,
-			   readbuf, sizeof (readbuf));
-  
-  if ( bytesread < 0 )
-    {		/* Error from sl_senddata() */
-      return -1;
-    }
-  
+  bytesread = sl_senddata (slconn, (void *)sendstr, strlen (sendstr), slconn->sladdr,
+                           readbuf, sizeof (readbuf));
+
+  if (bytesread < 0)
+  { /* Error from sl_senddata() */
+    return -1;
+  }
+
   /* Check response to BATCH */
   if (!strncmp (readbuf, "OK\r", 3) && bytesread >= 4)
-    {
-      sl_log_r (slconn, 1, 2, "[%s] BATCH accepted\n", slconn->sladdr);
-      slconn->batchmode = 2;
-    }
+  {
+    sl_log_r (slconn, 1, 2, "[%s] BATCH accepted\n", slconn->sladdr);
+    slconn->batchmode = 2;
+  }
   else if (!strncmp (readbuf, "ERROR\r", 6) && bytesread >= 7)
-    {
-      sl_log_r (slconn, 1, 2, "[%s] BATCH not accepted\n", slconn->sladdr);
-    }
+  {
+    sl_log_r (slconn, 1, 2, "[%s] BATCH not accepted\n", slconn->sladdr);
+  }
   else
-    {
-      sl_log_r (slconn, 2, 0,
-		"[%s] invalid response to BATCH command: %.*s\n",
-		slconn->sladdr, bytesread, readbuf);
-      return -1;
-    }
-  
-  return 0;
-}  /* End of sl_batchmode() */
+  {
+    sl_log_r (slconn, 2, 0,
+              "[%s] invalid response to BATCH command: %.*s\n",
+              slconn->sladdr, bytesread, readbuf);
+    return -1;
+  }
 
+  return 0;
+} /* End of sl_batchmode() */
 
 /***************************************************************************
  * sl_ping:
@@ -1067,63 +1059,62 @@ sl_batchmode (SLCD * slconn)
  *  -2  Could not open network connection
  ***************************************************************************/
 int
-sl_ping (SLCD * slconn, char *serverid, char *site)
+sl_ping (SLCD *slconn, char *serverid, char *site)
 {
   int servcnt = 0;
   int sitecnt = 0;
-  char sendstr[100];		/* A buffer for command strings */
-  char servstr[100];		/* The remote server ident */
-  char sitestr[100];		/* The site/data center ident */
-  
+  char sendstr[100]; /* A buffer for command strings */
+  char servstr[100]; /* The remote server ident */
+  char sitestr[100]; /* The site/data center ident */
+
   /* Open network connection to server */
-  if ( sl_connect (slconn, 0) == -1 )
-    {
-      sl_log_r (slconn, 2, 1, "Could not connect to server\n");
-      return -2;
-    }
-  
+  if (sl_connect (slconn, 0) == -1)
+  {
+    sl_log_r (slconn, 2, 1, "Could not connect to server\n");
+    return -2;
+  }
+
   /* Send HELLO */
   sprintf (sendstr, "HELLO\r");
   sl_log_r (slconn, 1, 2, "[%s] sending: HELLO\n", slconn->sladdr);
-  sl_senddata (slconn, (void *) sendstr, strlen (sendstr), slconn->sladdr,
-	       NULL, 0);
-  
-  /* Recv the two lines of response */
-  if ( sl_recvresp (slconn, (void *) servstr, (size_t) sizeof (servstr), 
-		    sendstr, slconn->sladdr) < 0 )
-    {
-      return -1;
-    }
-  
-  if ( sl_recvresp (slconn, (void *) sitestr, (size_t) sizeof (sitestr),
-		    sendstr, slconn->sladdr) < 0 )
-    {
-      return -1;
-    }
-  
-  servcnt = strcspn (servstr, "\r");
-  if ( servcnt > 90 )
-    {
-      servcnt = 90;
-    }
-  servstr[servcnt] = '\0';
-  
-  sitecnt = strcspn (sitestr, "\r");
-  if ( sitecnt > 90 )
-    {
-      sitecnt = 90;
-    }
-  sitestr[sitecnt] = '\0';
-  
-  /* Copy the response strings into the supplied strings */
-  strncpy (serverid, servstr, sizeof(servstr));
-  strncpy (site, sitestr, sizeof(sitestr));
-  
-  slconn->link = sl_disconnect (slconn);
-  
-  return 0;
-}  /* End of sl_ping() */
+  sl_senddata (slconn, (void *)sendstr, strlen (sendstr), slconn->sladdr,
+               NULL, 0);
 
+  /* Recv the two lines of response */
+  if (sl_recvresp (slconn, (void *)servstr, (size_t)sizeof (servstr),
+                   sendstr, slconn->sladdr) < 0)
+  {
+    return -1;
+  }
+
+  if (sl_recvresp (slconn, (void *)sitestr, (size_t)sizeof (sitestr),
+                   sendstr, slconn->sladdr) < 0)
+  {
+    return -1;
+  }
+
+  servcnt = strcspn (servstr, "\r");
+  if (servcnt > 90)
+  {
+    servcnt = 90;
+  }
+  servstr[servcnt] = '\0';
+
+  sitecnt = strcspn (sitestr, "\r");
+  if (sitecnt > 90)
+  {
+    sitecnt = 90;
+  }
+  sitestr[sitecnt] = '\0';
+
+  /* Copy the response strings into the supplied strings */
+  strncpy (serverid, servstr, sizeof (servstr));
+  strncpy (site, sitestr, sizeof (sitestr));
+
+  slconn->link = sl_disconnect (slconn);
+
+  return 0;
+} /* End of sl_ping() */
 
 /***************************************************************************
  * sl_checksock:
@@ -1138,38 +1129,37 @@ sl_ping (SLCD * slconn, char *serverid, char *site)
  * -1 = errors
  ***************************************************************************/
 int
-sl_checksock (int sock, int tosec, int tousec)
+sl_checksock (SOCKET sock, int tosec, int tousec)
 {
   int sret;
-  int ret = -1;			/* default is failure */
+  int ret = -1; /* default is failure */
   char testbuf[1];
   fd_set checkset;
   struct timeval to;
 
   FD_ZERO (&checkset);
-  FD_SET ((unsigned int)sock, &checkset);
+  FD_SET (sock, &checkset);
 
-  to.tv_sec = tosec;
+  to.tv_sec  = tosec;
   to.tv_usec = tousec;
 
   /* Check write ability with select() */
   if ((sret = select (sock + 1, NULL, &checkset, NULL, &to)) > 0)
     ret = 1;
   else if (sret == 0)
-    ret = 0;			/* time-out expired */
+    ret = 0; /* time-out expired */
 
   /* Check read ability with recv() */
   if (ret && (recv (sock, testbuf, sizeof (char), MSG_PEEK)) <= 0)
-    {
-      if (! slp_noblockcheck())
-	ret = 1;		/* no data for non-blocking IO */
-      else
-	ret = -1;
-    }
+  {
+    if (!slp_noblockcheck ())
+      ret = 1; /* no data for non-blocking IO */
+    else
+      ret = -1;
+  }
 
   return ret;
-}  /* End of sl_checksock() */
-
+} /* End of sl_checksock() */
 
 /***************************************************************************
  * sl_senddata:
@@ -1185,40 +1175,39 @@ sl_checksock (int sock, int tosec, int tousec)
  * received (0 if 'resp' == NULL).
  ***************************************************************************/
 int
-sl_senddata (SLCD * slconn, void *buffer, size_t buflen,
-	     const char *ident, void *resp, int resplen)
+sl_senddata (SLCD *slconn, void *buffer, size_t buflen,
+             const char *ident, void *resp, int resplen)
 {
-  
-  int bytesread = 0;		/* bytes read into resp */
-  
-  if ( send (slconn->link, buffer, buflen, 0) < 0 )
-    {
-      sl_log_r (slconn, 2, 0, "[%s] error sending '%.*s'\n", ident,
-		strcspn ((char *) buffer, "\r\n"), (char *) buffer);
-      return -1;
-    }
-  
-  /* If requested collect the response */
-  if ( resp != NULL )
-    {
-      /* Clear response buffer */
-      memset (resp, 0, resplen);
-      
-      if ( slconn->batchmode == 2 )
-        {
-	  /* Fake OK response */
-	  strcpy(resp, "OK\r\n");
-	  bytesread = 4;
-	}
-      else
-        {
-          bytesread = sl_recvresp (slconn, resp, resplen, buffer, ident);
-	}
-    }
-  
-  return bytesread;
-}  /* End of sl_senddata() */
 
+  int bytesread = 0; /* bytes read into resp */
+
+  if (send (slconn->link, buffer, buflen, 0) < 0)
+  {
+    sl_log_r (slconn, 2, 0, "[%s] error sending '%.*s'\n", ident,
+              strcspn ((char *)buffer, "\r\n"), (char *)buffer);
+    return -1;
+  }
+
+  /* If requested collect the response */
+  if (resp != NULL)
+  {
+    /* Clear response buffer */
+    memset (resp, 0, resplen);
+
+    if (slconn->batchmode == 2)
+    {
+      /* Fake OK response */
+      strcpy (resp, "OK\r\n");
+      bytesread = 4;
+    }
+    else
+    {
+      bytesread = sl_recvresp (slconn, resp, resplen, buffer, ident);
+    }
+  }
+
+  return bytesread;
+} /* End of sl_senddata() */
 
 /***************************************************************************
  * sl_recvdata:
@@ -1231,40 +1220,39 @@ sl_senddata (SLCD * slconn, void *buffer, size_t buflen,
  * of bytes read on success.
  ***************************************************************************/
 int
-sl_recvdata (SLCD * slconn, void *buffer, size_t maxbytes,
-	     const char *ident)
+sl_recvdata (SLCD *slconn, void *buffer, size_t maxbytes,
+             const char *ident)
 {
   int bytesread = 0;
-  
-  if ( buffer == NULL )
-    {
-      return -1;
-    }
-  
-  bytesread = recv (slconn->link, buffer, maxbytes, 0);
-  
-  if ( bytesread == 0 )		/* should indicate TCP FIN or EOF */
-    {
-      sl_log_r (slconn, 1, 1, "[%s] recv():%d TCP FIN or EOF received\n",
-		ident, bytesread);
-      return -1;
-    }
-  else if ( bytesread < 0 )
-    {
-      if ( slp_noblockcheck() )
-	{
-	  sl_log_r (slconn, 2, 0, "[%s] recv():%d %s\n", ident, bytesread,
-		    slp_strerror ());
-	  return -1;
-	}
 
-      /* no data available for NONBLOCKing IO */
-      return 0;
+  if (buffer == NULL)
+  {
+    return -1;
+  }
+
+  bytesread = recv (slconn->link, buffer, maxbytes, 0);
+
+  if (bytesread == 0) /* should indicate TCP FIN or EOF */
+  {
+    sl_log_r (slconn, 1, 1, "[%s] recv():%d TCP FIN or EOF received\n",
+              ident, bytesread);
+    return -1;
+  }
+  else if (bytesread < 0)
+  {
+    if (slp_noblockcheck ())
+    {
+      sl_log_r (slconn, 2, 0, "[%s] recv():%d %s\n", ident, bytesread,
+                slp_strerror ());
+      return -1;
     }
+
+    /* no data available for NONBLOCKing IO */
+    return 0;
+  }
 
   return bytesread;
-}  /* End of sl_recvdata() */
-
+} /* End of sl_recvdata() */
 
 /***************************************************************************
  * sl_recvresp:
@@ -1283,70 +1271,70 @@ sl_recvdata (SLCD * slconn, void *buffer, size_t maxbytes,
  * Returns -1 on error/EOF and the number of bytes read on success.
  ***************************************************************************/
 int
-sl_recvresp (SLCD * slconn, void *buffer, size_t maxbytes,
-	     const char *command, const char *ident)
+sl_recvresp (SLCD *slconn, void *buffer, size_t maxbytes,
+             const char *command, const char *ident)
 {
-  
-  int bytesread = 0;		/* total bytes read */
-  int recvret   = 0;            /* return from sl_recvdata */
-  int ackcnt    = 0;		/* counter for the read loop */
-  int ackpoll   = 50000;	/* poll at 0.05 seconds for reading */
-  
-  if ( buffer == NULL )
+
+  int bytesread = 0;     /* total bytes read */
+  int recvret   = 0;     /* return from sl_recvdata */
+  int ackcnt    = 0;     /* counter for the read loop */
+  int ackpoll   = 50000; /* poll at 0.05 seconds for reading */
+
+  if (buffer == NULL)
+  {
+    return -1;
+  }
+
+  /* Clear the receiving buffer */
+  memset (buffer, 0, maxbytes);
+
+  /* Recv a byte at a time and wait up to 30 seconds for a response */
+  while (bytesread < maxbytes)
+  {
+    recvret = sl_recvdata (slconn, (char *)buffer + bytesread, 1, ident);
+
+    /* Trap door for termination */
+    if (slconn->terminate)
     {
       return -1;
     }
-  
-  /* Clear the receiving buffer */
-  memset (buffer, 0, maxbytes);
-  
-  /* Recv a byte at a time and wait up to 30 seconds for a response */
-  while ( bytesread < maxbytes )
+
+    if (recvret > 0)
     {
-      recvret = sl_recvdata (slconn, (char *)buffer + bytesread, 1, ident);
-      
-      /* Trap door for termination */
-      if ( slconn->terminate )
-	{
-	  return -1;
-	}
-      
-      if ( recvret > 0 )
-	{
-	  bytesread += recvret;
-	}
-      else if ( recvret < 0 )
-	{
-	  sl_log_r (slconn, 2, 0, "[%s] bad response to '%.*s'\n",
-		    ident, strcspn ((char *) command, "\r\n"),
-		    (char *) command);
-	  return -1;
-	}
-      
-      /* Trap door if '\r\n' is recv'd */
-      if ( bytesread >= 2 &&
-	   *(char *)((char *)buffer + bytesread - 2) == '\r' &&
-	   *(char *)((char *)buffer + bytesread - 1) == '\n' )
-	{
-	  return bytesread;
-	}
-      
-      /* Trap door if 30 seconds has elapsed, (ackpoll x 600) */
-      if ( ackcnt > 600 )
-        {
-	  sl_log_r (slconn, 2, 0, "[%s] timeout waiting for response to '%.*s'\n",
-		    ident, strcspn ((char *) command, "\r\n"),
-		    (char *) command);
-	  return -1;
-	}
-      
-      /* Delay if no data received */
-      if ( recvret == 0 )
-	{
-	  slp_usleep (ackpoll);
-	  ackcnt++;
-	}
+      bytesread += recvret;
     }
-  
+    else if (recvret < 0)
+    {
+      sl_log_r (slconn, 2, 0, "[%s] bad response to '%.*s'\n",
+                ident, strcspn ((char *)command, "\r\n"),
+                (char *)command);
+      return -1;
+    }
+
+    /* Trap door if '\r\n' is recv'd */
+    if (bytesread >= 2 &&
+        *(char *)((char *)buffer + bytesread - 2) == '\r' &&
+        *(char *)((char *)buffer + bytesread - 1) == '\n')
+    {
+      return bytesread;
+    }
+
+    /* Trap door if 30 seconds has elapsed, (ackpoll x 600) */
+    if (ackcnt > 600)
+    {
+      sl_log_r (slconn, 2, 0, "[%s] timeout waiting for response to '%.*s'\n",
+                ident, strcspn ((char *)command, "\r\n"),
+                (char *)command);
+      return -1;
+    }
+
+    /* Delay if no data received */
+    if (recvret == 0)
+    {
+      slp_usleep (ackpoll);
+      ackcnt++;
+    }
+  }
+
   return bytesread;
-}  /* End of sl_recvresp() */
+} /* End of sl_recvresp() */

--- a/bin/rt/slink2orb/libslink/slplatform.c
+++ b/bin/rt/slink2orb/libslink/slplatform.c
@@ -1,62 +1,46 @@
 /***************************************************************************
  * slplatform.c:
- * 
+ *
  * Platform portability routines.
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public License
- * as published by the Free Software Foundation; either version 2 of
- * the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License (GNU-LGPL) for more details.  The
- * GNU-LGPL and further information can be found here:
- * http://www.gnu.org/
- *
- * Written by Chad Trabant, ORFEUS/EC-Project MEREDIAN
- *
- * modified: 2008.029
+ * modified: 2016.290
  ***************************************************************************/
 
-#include <fcntl.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
-#include <time.h>
 #include <string.h>
-#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
 
 #include "libslink.h"
-
 
 /***************************************************************************
  * slp_sockstartup:
  *
  * Startup the network socket layer.  At the moment this is only meaningful
- * for the WIN32 platform.
+ * for the WIN platform.
  *
  * Returns -1 on errors and 0 on success.
  ***************************************************************************/
 int
 slp_sockstartup (void)
 {
-#if defined(SLP_WIN32)
+#if defined(SLP_WIN)
   WORD wVersionRequested;
   WSADATA wsaData;
 
   /* Check for Windows sockets version 2.2 */
-  wVersionRequested = MAKEWORD( 2, 2 );
+  wVersionRequested = MAKEWORD (2, 2);
 
-  if ( WSAStartup( wVersionRequested, &wsaData ) )
+  if (WSAStartup (wVersionRequested, &wsaData))
     return -1;
 
 #endif
 
   return 0;
-}  /* End of slp_sockstartup() */
-
+} /* End of slp_sockstartup() */
 
 /***************************************************************************
  * slp_sockconnect:
@@ -66,25 +50,24 @@ slp_sockstartup (void)
  * Returns -1 on errors and 0 on success.
  ***************************************************************************/
 int
-slp_sockconnect (int sock, struct sockaddr * inetaddr, int addrlen)
+slp_sockconnect (SOCKET sock, struct sockaddr *inetaddr, int addrlen)
 {
-#if defined(SLP_WIN32)
+#if defined(SLP_WIN)
   if ((connect (sock, inetaddr, addrlen)) == SOCKET_ERROR)
-    {
-      if (WSAGetLastError() != WSAEWOULDBLOCK)
-	return -1;
-    }
+  {
+    if (WSAGetLastError () != WSAEWOULDBLOCK)
+      return -1;
+  }
 #else
   if ((connect (sock, inetaddr, addrlen)) == -1)
-    {
-      if (errno != EINPROGRESS)
-	return -1;
-    }
+  {
+    if (errno != EINPROGRESS)
+      return -1;
+  }
 #endif
 
   return 0;
-}  /* End of slp_sockconnect() */
-
+} /* End of slp_sockconnect() */
 
 /***************************************************************************
  * slp_sockclose:
@@ -94,15 +77,14 @@ slp_sockconnect (int sock, struct sockaddr * inetaddr, int addrlen)
  * Returns -1 on errors and 0 on success.
  ***************************************************************************/
 int
-slp_sockclose (int sock)
+slp_sockclose (SOCKET sock)
 {
-#if defined(SLP_WIN32)
+#if defined(SLP_WIN)
   return closesocket (sock);
 #else
   return close (sock);
 #endif
-}  /* End of slp_sockclose() */
-
+} /* End of slp_sockclose() */
 
 /***************************************************************************
  * slp_socknoblock:
@@ -112,26 +94,25 @@ slp_sockclose (int sock)
  * Returns -1 on errors and 0 on success.
  ***************************************************************************/
 int
-slp_socknoblock (int sock)
+slp_socknoblock (SOCKET sock)
 {
-#if defined(SLP_WIN32)
+#if defined(SLP_WIN)
   u_long flag = 1;
 
-  if (ioctlsocket(sock, FIONBIO, &flag) == -1)
+  if (ioctlsocket (sock, FIONBIO, &flag) == -1)
     return -1;
 
 #else
-  int flags = fcntl(sock, F_GETFL, 0);
+  int flags = fcntl (sock, F_GETFL, 0);
 
   flags |= O_NONBLOCK;
-  if (fcntl(sock, F_SETFL, flags) == -1)
+  if (fcntl (sock, F_SETFL, flags) == -1)
     return -1;
 
 #endif
 
   return 0;
-}  /* End of slp_socknoblock() */
-
+} /* End of slp_socknoblock() */
 
 /***************************************************************************
  * slp_noblockcheck:
@@ -142,8 +123,8 @@ slp_socknoblock (int sock)
 int
 slp_noblockcheck (void)
 {
-#if defined(SLP_WIN32)
-  if (WSAGetLastError() != WSAEWOULDBLOCK)
+#if defined(SLP_WIN)
+  if (WSAGetLastError () != WSAEWOULDBLOCK)
     return -1;
 
 #else
@@ -154,112 +135,83 @@ slp_noblockcheck (void)
 
   /* no data available for NONBLOCKing IO */
   return 0;
-}  /* End of slp_noblockcheck() */
-
+} /* End of slp_noblockcheck() */
 
 /***************************************************************************
  * slp_getaddrinfo:
  *
  * Resolve IP addresses and provide parameters needed for connect().
- * On Win32 this will use gethostbyname() for portability (only newer
- * Windows platforms support getaddrinfo).  On Linux (glibc2) and
- * Solaris the reentrant gethostbyname_r() is used.
  *
- * The real solution to name resolution is to use POSIX 1003.1g
- * getaddrinfo() because it is standardized, thread-safe and protocol
- * independent (i.e. IPv4, IPv6, etc.).  Unfortunately it is not
- * supported on many older platforms.
+ * On WIN this will use the older gethostbyname() for consistent
+ * compatibility with older OS versions.  In the future we should be
+ * able to use getaddrinfo() even on Windows.
  *
- * Return 0 on success and non-zero on error.
+ * On all other platforms use POSIX 1003.1g getaddrinfo() because it
+ * is standardized, thread-safe and protocol independent (i.e. IPv4,
+ * IPv6, etc.) and has broad support.
+ *
+ * Currently, this routine is limited to IPv4 addresses.
+ *
+ * Return 0 on success and non-zero on error.  On everything but WIN
+ * an error value is the return value of getaddrinfo().
  ***************************************************************************/
 int
-slp_getaddrinfo (char * nodename, char * nodeport,
-		 struct sockaddr * addr, size_t * addrlen)
+slp_getaddrinfo (char *nodename, char *nodeport,
+                 struct sockaddr *addr, size_t *addrlen)
 {
-#if defined(SLP_WIN32)
+#if defined(SLP_WIN)
   struct hostent *result;
   struct sockaddr_in inet_addr;
   long int nport;
   char *tail;
 
-  if ( (result = gethostbyname (nodename)) == NULL )
-    {
-      return -1;
-    }
+  if ((result = gethostbyname (nodename)) == NULL)
+  {
+    return -1;
+  }
 
   nport = strtoul (nodeport, &tail, 0);
 
   memset (&inet_addr, 0, sizeof (inet_addr));
   inet_addr.sin_family = AF_INET;
-  inet_addr.sin_port = htons ((unsigned short int)nport);
-  inet_addr.sin_addr = *(struct in_addr *) result->h_addr_list[0];
-  
-  *addr = *((struct sockaddr *) &inet_addr);
-  *addrlen = sizeof(inet_addr);
+  inet_addr.sin_port   = htons ((unsigned short int)nport);
+  inet_addr.sin_addr   = *(struct in_addr *)result->h_addr_list[0];
 
-#elif defined(SLP_GLIBC2) || defined(SLP_SOLARIS)
-  /* 1024 bytes should be enough for the vast majority of cases.  If
-     not (e.g. the node has a lot of aliases) this call will fail. */
-
-  char buffer[1024];
-  struct hostent *result;
-  struct hostent result_buffer;
-  struct sockaddr_in inet_addr;
-  int my_error;
-  long int nport;
-  char *tail;
-
-  #if defined(SLP_GLIBC2)
-  gethostbyname_r (nodename, &result_buffer,
-		   buffer, sizeof(buffer) - 1,
-		   &result, &my_error);
-  #endif
-
-  #if defined(SLP_SOLARIS)
-  result = gethostbyname_r (nodename, &result_buffer,
-                            buffer, sizeof(buffer) - 1,
-			    &my_error);
-  #endif
-
-  if ( !result )
-    return my_error;
-
-  nport = strtoul (nodeport, &tail, 0);
-
-  memset (&inet_addr, 0, sizeof (inet_addr));
-  inet_addr.sin_family = AF_INET;
-  inet_addr.sin_port = htons ((unsigned short int)nport);
-  inet_addr.sin_addr = *(struct in_addr *) result->h_addr_list[0];
-  
-  *addr = *((struct sockaddr *) &inet_addr);
-  *addrlen = sizeof(inet_addr);
+  memcpy (addr, &inet_addr, sizeof (struct sockaddr));
+  *addrlen = sizeof (inet_addr);
 
 #else
-  /* This will be used by all others, it is not properly supported
-     by some but this is the future of name resolution. */
-
-  struct addrinfo *result;
+  /* getaddrinfo() will be used by all others */
+  struct addrinfo *ptr    = NULL;
+  struct addrinfo *result = NULL;
   struct addrinfo hints;
+  int rv;
 
-  memset (&hints, 0, sizeof(hints));
-  hints.ai_family = PF_INET;
+  memset (&hints, 0, sizeof (hints));
+  hints.ai_family   = AF_INET;
   hints.ai_socktype = SOCK_STREAM;
-  
-  if ( getaddrinfo (nodename, nodeport, &hints, &result) )
-    {
-      return -1;
-    }
 
-  *addr = *(result->ai_addr);
-  *addrlen = result->ai_addrlen;
+  if ((rv = getaddrinfo (nodename, nodeport, &hints, &result)))
+  {
+    return rv;
+  }
+
+  for (ptr = result; ptr != NULL; ptr = ptr->ai_next)
+  {
+    if (ptr->ai_family == AF_INET)
+    {
+      memcpy (addr, ptr->ai_addr, sizeof (struct sockaddr));
+      *addrlen = (size_t)ptr->ai_addrlen;
+      break;
+    }
+  }
 
   freeaddrinfo (result);
 
 #endif
 
   return 0;
-}  /* End of slp_getaddrinfo() */
-
+} /* End of slp_getaddrinfo() */
 
 /***************************************************************************
  * slp_openfile:
@@ -277,17 +229,16 @@ slp_getaddrinfo (char * nodename, char * nodeport,
 int
 slp_openfile (const char *filename, char perm)
 {
-#if defined(SLP_WIN32)
+#if defined(SLP_WIN)
   int flags = (perm == 'w') ? (_O_RDWR | _O_CREAT | _O_BINARY) : (_O_RDONLY | _O_BINARY);
-  int mode = (_S_IREAD | _S_IWRITE);
+  int mode  = (_S_IREAD | _S_IWRITE);
 #else
-  int flags = (perm == 'w') ? (O_RDWR | O_CREAT) : O_RDONLY;
+  int flags   = (perm == 'w') ? (O_RDWR | O_CREAT) : O_RDONLY;
   mode_t mode = (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 #endif
-  
-  return open (filename, flags, mode);
-}  /* End of slp_openfile() */
 
+  return open (filename, flags, mode);
+} /* End of slp_openfile() */
 
 /***************************************************************************
  * slp_strerror:
@@ -298,24 +249,23 @@ slp_openfile (const char *filename, char perm)
 const char *
 slp_strerror (void)
 {
-#if defined(SLP_WIN32)
+#if defined(SLP_WIN)
   static char errorstr[100];
 
-  snprintf (errorstr, sizeof(errorstr), "%d", WSAGetLastError());
-  return (const char *) errorstr;
+  snprintf (errorstr, sizeof (errorstr), "%d", WSAGetLastError ());
+  return (const char *)errorstr;
 
 #else
-  return (const char *) strerror (errno);
+  return (const char *)strerror (errno);
 
 #endif
-}  /* End of slp_strerror() */
-
+} /* End of slp_strerror() */
 
 /***************************************************************************
  * slp_dtime:
  *
  * Get the current time from the system as Unix/POSIX epoch time with double
- * precision.  On the WIN32 platform this function has millisecond
+ * precision.  On the WIN platform this function has millisecond
  * resulution, on *nix platforms this function has microsecond resolution.
  *
  * Return a double precision Unix/POSIX epoch time.
@@ -323,69 +273,68 @@ slp_strerror (void)
 double
 slp_dtime (void)
 {
-#if defined(SLP_WIN32)
+#if defined(SLP_WIN)
 
   static const __int64 SECS_BETWEEN_EPOCHS = 11644473600;
-  static const __int64 SECS_TO_100NS = 10000000; /* 10^7 */
+  static const __int64 SECS_TO_100NS       = 10000000; /* 10^7 */
 
   __int64 UnixTime;
   SYSTEMTIME SystemTime;
   FILETIME FileTime;
   double depoch;
 
-  GetSystemTime(&SystemTime);
-  SystemTimeToFileTime(&SystemTime, &FileTime);
+  GetSystemTime (&SystemTime);
+  SystemTimeToFileTime (&SystemTime, &FileTime);
 
   /* Get the full win32 epoch value, in 100ns */
-  UnixTime = ((__int64)FileTime.dwHighDateTime << 32) + 
-    FileTime.dwLowDateTime;
+  UnixTime = ((__int64)FileTime.dwHighDateTime << 32) +
+             FileTime.dwLowDateTime;
 
   /* Convert to the Unix epoch */
   UnixTime -= (SECS_BETWEEN_EPOCHS * SECS_TO_100NS);
-  
+
   UnixTime /= SECS_TO_100NS; /* now convert to seconds */
-  
-  if ( (double)UnixTime != UnixTime )
-    {
-      sl_log_r (NULL, 2, 0, "slp_dtime(): resulting value is too big for a double value\n");
-    }
-  
-  depoch = (double) UnixTime + ((double) SystemTime.wMilliseconds / 1000.0);
+
+  if ((double)UnixTime != UnixTime)
+  {
+    sl_log_r (NULL, 2, 0, "slp_dtime(): resulting value is too big for a double value\n");
+  }
+
+  depoch = (double)UnixTime + ((double)SystemTime.wMilliseconds / 1000.0);
 
   return depoch;
 
 #else
 
   struct timeval tv;
-  
-  gettimeofday (&tv, (struct timezone *) 0);
-  return ((double) tv.tv_sec + ((double) tv.tv_usec / 1000000.0));
+
+  gettimeofday (&tv, (struct timezone *)0);
+  return ((double)tv.tv_sec + ((double)tv.tv_usec / 1000000.0));
 
 #endif
-}  /* End of slp_dtime() */
-
+} /* End of slp_dtime() */
 
 /***************************************************************************
  * slp_usleep:
- * 
+ *
  * Sleep for a given number of microseconds.  Under Win32 use SleepEx()
  * and for all others use the POSIX.4 nanosleep().
  ***************************************************************************/
 void
 slp_usleep (unsigned long int useconds)
 {
-#if defined(SLP_WIN32)
+#if defined(SLP_WIN)
 
   SleepEx ((useconds / 1000), 1);
 
 #else
-  
+
   struct timespec treq, trem;
-  
-  treq.tv_sec = (time_t) (useconds / 1e6);
-  treq.tv_nsec = (long) ((useconds * 1e3) - (treq.tv_sec * 1e9));
-  
+
+  treq.tv_sec  = (time_t) (useconds / 1e6);
+  treq.tv_nsec = (long)((useconds * 1e3) - (treq.tv_sec * 1e9));
+
   nanosleep (&treq, &trem);
 
 #endif
-}  /* End of slp_usleep() */
+} /* End of slp_usleep() */

--- a/bin/rt/slink2orb/libslink/slplatform.h
+++ b/bin/rt/slink2orb/libslink/slplatform.h
@@ -1,24 +1,26 @@
 /***************************************************************************
  * slplatform.h:
- * 
+ *
  * Platform specific headers.  This file provides a basic level of platform
  * portability.
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public License
- * as published by the Free Software Foundation; either version 2 of
- * the License, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License (GNU-LGPL) for more details.  The
- * GNU-LGPL and further information can be found here:
- * http://www.gnu.org/
+ * Lesser General Public License (GNU-LGPL) for more details.
  *
- * Written by Chad Trabant, ORFEUS/EC-Project MEREDIAN
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software.
+ * If not, see <https://www.gnu.org/licenses/>.
  *
- * modified: 2008.078
+ * Copyright (C) 2016 Chad Trabant, IRIS Data Management Center
+ *
+ * modified: 2016.288
  ***************************************************************************/
 
 #ifndef SLPLATFORM_H
@@ -28,87 +30,95 @@
 extern "C" {
 #endif
 
-
-  /* Portability to the XScale (ARM) architecture
-   * requires a packed attribute in certain places
-   * but this only works with GCC for now.
-   */
-
+/* Portability to the XScale (ARM) architecture requires a packed
+ * attribute in certain places but this only works with GCC for now. */
 #if defined (__GNUC__)
   #define SLP_PACKED __attribute__ ((packed))
 #else
   #define SLP_PACKED
-#endif  
+#endif
 
-  /* Make some guesses about the system libraries based
-   * on the architecture.  Currently the assumptions are:
-   * Linux => glibc2 (SLP_GLIBC2)
-   * Sun => Solaris (SLP_SOLARIS)
-   * WIN32 => WIN32 and Windows Sockets 2 (SLP_WIN32)
-   * Apple => Mac OS X (SLP_DARWIN)
-   */
+/* C99 standard headers */
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <time.h>
+#include <string.h>
+#include <ctype.h>
 
-#if defined(__linux__) || defined(__linux)
-  #define SLP_GLIBC2 1
+#if defined(__linux__) || defined(__linux) || defined(__CYGWIN__)
+  #define SLP_LINUX 1
+  #define SLP_GLIBC2 1 /* Deprecated */
 
-  #include <stdlib.h>
   #include <unistd.h>
-  #include <stdarg.h>
   #include <inttypes.h>
+  #include <sys/time.h>
+  #include <sys/socket.h>
+  #include <netinet/in.h>
+  #include <errno.h>
+  #include <netdb.h>
+
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+  #define SLP_BSD
+  #define SLP_DARWIN 1 /* Deprecated */
+
+  #include <unistd.h>
+  #include <inttypes.h>
+  #include <sys/time.h>
+  #include <errno.h>
+  #include <sys/types.h>
   #include <sys/socket.h>
   #include <netinet/in.h>
   #include <netdb.h>
-  #include <sys/time.h>
-   
+
 #elif defined(__sun__) || defined(__sun)
   #define SLP_SOLARIS 1
 
-  #include <stdlib.h>
   #include <unistd.h>
-  #include <stdarg.h>
   #include <inttypes.h>
+  #include <sys/time.h>
   #include <errno.h>
   #include <sys/types.h>
   #include <sys/stat.h>
   #include <sys/socket.h>
   #include <netinet/in.h>
   #include <netdb.h>
-  #include <sys/time.h>
 
-#elif defined(WIN32)
-  #define SLP_WIN32 1
+#elif defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+  #define SLP_WIN 1
+  #define SLP_WIN32 1 /* Deprecated */
 
+  #include <winsock2.h>
+  #include <ws2tcpip.h>
   #include <windows.h>
-  #include <stdarg.h>
-  #include <winsock.h>
   #include <io.h>
+
+  /* For MSVC 2012 and earlier define standard int types, otherwise use inttypes.h */
+  #if defined(_MSC_VER) && _MSC_VER <= 1700
+    typedef signed char int8_t;
+    typedef unsigned char uint8_t;
+    typedef signed short int int16_t;
+    typedef unsigned short int uint16_t;
+    typedef signed int int32_t;
+    typedef unsigned int uint32_t;
+    typedef signed __int64 int64_t;
+    typedef unsigned __int64 uint64_t;
+  #else
+    #include <inttypes.h>
+  #endif
+
+  #if defined(_MSC_VER)
+    #if !defined(PRId64)
+      #define PRId64 "I64d"
+    #endif
+    #if !defined(SCNd64)
+      #define SCNd64 "I64d"
+    #endif
+  #endif
 
   #define snprintf _snprintf
   #define vsnprintf _vsnprintf
   #define strncasecmp _strnicmp
-
-  typedef signed char int8_t;
-  typedef unsigned char uint8_t;
-  typedef signed short int int16_t;
-  typedef unsigned short int uint16_t;
-  typedef signed int int32_t;
-  typedef unsigned int uint32_t;
-  typedef signed __int64 int64_t;
-  typedef unsigned __int64 uint64_t;
-
-#elif defined(__APPLE__)
-  #define SLP_DARWIN 1
-
-  #include <stdlib.h>
-  #include <unistd.h>
-  #include <stdarg.h>
-  #include <inttypes.h>
-  #include <errno.h>
-  #include <sys/types.h>
-  #include <sys/socket.h>
-  #include <netinet/in.h>
-  #include <netdb.h>
-  #include <sys/time.h>
 
 #else
   typedef signed char int8_t;
@@ -122,12 +132,17 @@ extern "C" {
 
 #endif
 
+/* Use int for SOCKET if platform includes have not defined it */
+#ifndef SOCKET
+  #define SOCKET int
+#endif
+
 extern int slp_sockstartup (void);
-extern int slp_sockconnect (int sock, struct sockaddr * inetaddr, int addrlen);
-extern int slp_sockclose (int sock);
-extern int slp_socknoblock (int sock);
+extern int slp_sockconnect (SOCKET sock, struct sockaddr * inetaddr, int addrlen);
+extern int slp_sockclose (SOCKET sock);
+extern int slp_socknoblock (SOCKET sock);
 extern int slp_noblockcheck (void);
-extern int slp_getaddrinfo (char * nodename, char * nodeport, 
+extern int slp_getaddrinfo (char * nodename, char * nodeport,
 			    struct sockaddr * addr, size_t * addrlen);
 extern int slp_openfile (const char *filename, char perm);
 extern const char *slp_strerror(void);
@@ -137,5 +152,5 @@ extern void slp_usleep(unsigned long int useconds);
 #ifdef __cplusplus
 }
 #endif
- 
+
 #endif /* SLPLATFORM_H */

--- a/bin/rt/slink2orb/libslink/slutils.c
+++ b/bin/rt/slink2orb/libslink/slutils.c
@@ -5,12 +5,12 @@
  *
  * Written by Chad Trabant, ORFEUS/EC-Project MEREDIAN
  *
- * modified: 2012.152
+ * modified: 2016.287
  ***************************************************************************/
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "libslink.h"
@@ -18,8 +18,7 @@
 #include "globmatch.h"
 
 /* Function(s) only used in this source file */
-int update_stream (SLCD * slconn, SLpacket * slpack);
-
+int update_stream (SLCD *slconn, SLpacket *slpack);
 
 /***************************************************************************
  * sl_collect:
@@ -36,365 +35,365 @@ int update_stream (SLCD * slconn, SLpacket * slpack);
  * returned and the slpack pointer is set to NULL.
  ***************************************************************************/
 int
-sl_collect (SLCD * slconn, SLpacket ** slpack)
+sl_collect (SLCD *slconn, SLpacket **slpack)
 {
-  int    bytesread;
+  int bytesread;
   double current_time;
-  char   retpacket;
+  char retpacket;
 
   /* For select()ing during the read loop */
   struct timeval select_tv;
-  fd_set         select_fd;
-  int            select_ret;
+  fd_set select_fd;
+  int select_ret;
 
   *slpack = NULL;
 
   /* Check if the info was set */
-  if ( slconn->info != NULL )
-    {
-      slconn->stat->query_mode = InfoQuery;
-    }
-  
-  /* If the connection is not up check the SLCD and reset the timing variables */
-  if ( slconn->link == -1 )
-    {
-      if ( sl_checkslcd(slconn) )
-	{
-	  sl_log_r (slconn, 2, 0, "problems with the connection description\n");
-	  return SLTERMINATE;
-	}
+  if (slconn->info != NULL)
+  {
+    slconn->stat->query_mode = InfoQuery;
+  }
 
-      slconn->stat->netto_trig     = -1;	   /* Init net timeout trigger to reset state */
-      slconn->stat->keepalive_trig = -1;	   /* Init keepalive trigger to reset state */
+  /* If the connection is not up check the SLCD and reset the timing variables */
+  if (slconn->link == -1)
+  {
+    if (sl_checkslcd (slconn))
+    {
+      sl_log_r (slconn, 2, 0, "problems with the connection description\n");
+      return SLTERMINATE;
     }
+
+    slconn->stat->netto_trig     = -1; /* Init net timeout trigger to reset state */
+    slconn->stat->keepalive_trig = -1; /* Init keepalive trigger to reset state */
+  }
 
   /* Start the primary loop  */
   while (1)
+  {
+    if (!slconn->terminate)
     {
-      if ( ! slconn->terminate )
-	{
-	  if (slconn->link == -1)
-	    {
-	      slconn->stat->sl_state = SL_DOWN;
-	    }
-	  
-	  /* Check for network timeout */
-	  if (slconn->stat->sl_state == SL_DATA && slconn->netto && slconn->stat->netto_trig > 0)
-	    {
-	      sl_log_r (slconn, 1, 0, "network timeout (%ds), reconnecting in %ds\n",
-			slconn->netto, slconn->netdly);
-	      slconn->link = sl_disconnect (slconn);
-	      slconn->stat->sl_state = SL_DOWN;
-	      slconn->stat->netto_trig = -1;
-	      slconn->stat->netdly_trig = -1;
-	    }
-	  
-	  /* Check if a keepalive packet needs to be sent */
-	  if (slconn->stat->sl_state == SL_DATA && !slconn->stat->expect_info &&
-	      slconn->keepalive && slconn->stat->keepalive_trig > 0)
-	    {
-	      sl_log_r (slconn, 1, 2, "sending keepalive request\n");
-	      
-	      if ( sl_send_info (slconn, "ID", 3) != -1 )
-		{
-		  slconn->stat->query_mode = KeepAliveQuery;
-		  slconn->stat->expect_info = 1;
-		  slconn->stat->keepalive_trig = -1;
-		}
-	    }
-	  
-	  /* Check if an in-stream INFO request needs to be sent */
-	  if (slconn->stat->sl_state == SL_DATA && !slconn->stat->expect_info && slconn->info)
-	    {
-	      if ( sl_send_info (slconn, slconn->info, 1) != -1 )
-		{
-		  slconn->stat->query_mode = InfoQuery;
-		  slconn->stat->expect_info = 1;
-		}
-	      else
-		{
-		  slconn->stat->query_mode = NoQuery;
-		}
-	      
-	      slconn->info = NULL;
-	    }
-	  
-	  /* Throttle the loop while delaying */
-	  if (slconn->stat->sl_state == SL_DOWN && slconn->stat->netdly_trig > 0)
-	    {
-	      slp_usleep (500000);
-	    }
-	  
-	  /* Connect to remote SeedLink */
-	  if (slconn->stat->sl_state == SL_DOWN && slconn->stat->netdly_trig == 0)
-	    {
-	      if (sl_connect (slconn, 1) != -1)
-		{
-		  slconn->stat->sl_state = SL_UP;
-		}
-	      slconn->stat->netto_trig = -1;
-	      slconn->stat->netdly_trig = -1;
-	      slconn->stat->keepalive_trig = -1;
-	    }
-	  
-	  /* Negotiate/configure the connection */
-	  if (slconn->stat->sl_state == SL_UP)
-	    {
-	      int slconfret = 0;
-	      
-	      /* Only send query if a query is set and no streams are defined,
+      if (slconn->link == -1)
+      {
+        slconn->stat->sl_state = SL_DOWN;
+      }
+
+      /* Check for network timeout */
+      if (slconn->stat->sl_state == SL_DATA && slconn->netto && slconn->stat->netto_trig > 0)
+      {
+        sl_log_r (slconn, 1, 0, "network timeout (%ds), reconnecting in %ds\n",
+                  slconn->netto, slconn->netdly);
+        slconn->link              = sl_disconnect (slconn);
+        slconn->stat->sl_state    = SL_DOWN;
+        slconn->stat->netto_trig  = -1;
+        slconn->stat->netdly_trig = -1;
+      }
+
+      /* Check if a keepalive packet needs to be sent */
+      if (slconn->stat->sl_state == SL_DATA && !slconn->stat->expect_info &&
+          slconn->keepalive && slconn->stat->keepalive_trig > 0)
+      {
+        sl_log_r (slconn, 1, 2, "sending keepalive request\n");
+
+        if (sl_send_info (slconn, "ID", 3) != -1)
+        {
+          slconn->stat->query_mode     = KeepAliveQuery;
+          slconn->stat->expect_info    = 1;
+          slconn->stat->keepalive_trig = -1;
+        }
+      }
+
+      /* Check if an in-stream INFO request needs to be sent */
+      if (slconn->stat->sl_state == SL_DATA && !slconn->stat->expect_info && slconn->info)
+      {
+        if (sl_send_info (slconn, slconn->info, 1) != -1)
+        {
+          slconn->stat->query_mode  = InfoQuery;
+          slconn->stat->expect_info = 1;
+        }
+        else
+        {
+          slconn->stat->query_mode = NoQuery;
+        }
+
+        slconn->info = NULL;
+      }
+
+      /* Throttle the loop while delaying */
+      if (slconn->stat->sl_state == SL_DOWN && slconn->stat->netdly_trig > 0)
+      {
+        slp_usleep (500000);
+      }
+
+      /* Connect to remote SeedLink */
+      if (slconn->stat->sl_state == SL_DOWN && slconn->stat->netdly_trig == 0)
+      {
+        if (sl_connect (slconn, 1) != -1)
+        {
+          slconn->stat->sl_state = SL_UP;
+        }
+        slconn->stat->netto_trig     = -1;
+        slconn->stat->netdly_trig    = -1;
+        slconn->stat->keepalive_trig = -1;
+      }
+
+      /* Negotiate/configure the connection */
+      if (slconn->stat->sl_state == SL_UP)
+      {
+        int slconfret = 0;
+
+        /* Only send query if a query is set and no streams are defined,
 	       * if streams are defined we'll send the query after configuration.
 	       */
-	      if (slconn->info && slconn->streams == NULL)
-		{
-		  if ( sl_send_info (slconn, slconn->info, 1) != -1 )
-		    {
-		      slconn->stat->query_mode = InfoQuery;
-		      slconn->stat->expect_info = 1;
-		    }
-		  else
-		    {
-		      slconn->stat->query_mode = NoQuery;
-		      slconn->stat->expect_info = 0;
-		    }
-		  
-		  slconn->info = NULL;
-		}
-	      else
-		{
-		  slconfret = sl_configlink (slconn);
-		  slconn->stat->expect_info = 0;
-		}
-	      
-	      if (slconfret != -1)
-		{
-		  slconn->stat->recptr = 0;    /* initialize the data buffer pointers */
-		  slconn->stat->sendptr = 0;
-		  slconn->stat->sl_state = SL_DATA;
-		}
-	      else
-		{
-		  sl_log_r (slconn, 2, 0, "negotiation with remote SeedLink failed\n");
-		  slconn->link = sl_disconnect (slconn);
-		  slconn->stat->netdly_trig = -1;
-		}
-	    }
-	}
-      else /* We are terminating */
-	{
-	  if (slconn->link != -1)
-	    {
-	      slconn->link = sl_disconnect (slconn);
-	    }
+        if (slconn->info && slconn->streams == NULL)
+        {
+          if (sl_send_info (slconn, slconn->info, 1) != -1)
+          {
+            slconn->stat->query_mode  = InfoQuery;
+            slconn->stat->expect_info = 1;
+          }
+          else
+          {
+            slconn->stat->query_mode  = NoQuery;
+            slconn->stat->expect_info = 0;
+          }
 
-	  slconn->stat->sl_state = SL_DOWN;
-	}
+          slconn->info = NULL;
+        }
+        else
+        {
+          slconfret                 = sl_configlink (slconn);
+          slconn->stat->expect_info = 0;
+        }
 
-      /* DEBUG
+        if (slconfret != -1)
+        {
+          slconn->stat->recptr   = 0; /* initialize the data buffer pointers */
+          slconn->stat->sendptr  = 0;
+          slconn->stat->sl_state = SL_DATA;
+        }
+        else
+        {
+          sl_log_r (slconn, 2, 0, "negotiation with remote SeedLink failed\n");
+          slconn->link              = sl_disconnect (slconn);
+          slconn->stat->netdly_trig = -1;
+        }
+      }
+    }
+    else /* We are terminating */
+    {
+      if (slconn->link != -1)
+      {
+        slconn->link = sl_disconnect (slconn);
+      }
+
+      slconn->stat->sl_state = SL_DOWN;
+    }
+
+    /* DEBUG
       sl_log_r (slconn, 1, 0, "link: %d, sendptr: %d, recptr: %d, diff: %d\n",
                 slconn->link, slconn->stat->sendptr, slconn->stat->recptr,
 		(slconn->stat->recptr - slconn->stat->sendptr) );
       */
-	  
-      /* Process data in buffer */
-      while (slconn->stat->recptr - slconn->stat->sendptr >= SLHEADSIZE + SLRECSIZE)
-	{
-	  retpacket = 1;
-	  
-	  /* Check for an INFO packet */
-	  if (!strncmp (&slconn->stat->databuf[slconn->stat->sendptr], INFOSIGNATURE, 6))
-	    {
-	      char terminator;
-	      
-	      terminator = (slconn->stat->databuf[slconn->stat->sendptr + SLHEADSIZE - 1] != '*');
-	      
-	      if ( !slconn->stat->expect_info )
-		{
-		  sl_log_r (slconn, 2, 0, "unexpected INFO packet received, skipping\n");
-		}
-	      else
-		{
-		  if ( terminator )
-		    {
-		      slconn->stat->expect_info = 0;
-		    }
-		  
-		  /* Keep alive packets are not returned */
-		  if ( slconn->stat->query_mode == KeepAliveQuery )
-		    {
-		      retpacket = 0;
-		      
-		      if ( !terminator )
-			{
-			  sl_log_r (slconn, 2, 0, "non-terminated keep-alive packet received!?!\n");
-			}
-		      else
-			{
-			  sl_log_r (slconn, 1, 2, "keepalive packet received\n");
-			}
-		    }
-		}
-	      
-	      if ( slconn->stat->query_mode != NoQuery )
-		{
-		  slconn->stat->query_mode = NoQuery;
-		}
-	    }
-	  else    /* Update the stream chain entry if not an INFO packet */
-	    {
-	      if ( (update_stream (slconn, (SLpacket *) &slconn->stat->databuf[slconn->stat->sendptr])) == -1 )
-		{
-		  /* If updating didn't work the packet is broken */
-		  retpacket = 0;
-		}
-	    }
-	  
-	  /* Increment the send pointer */
-	  slconn->stat->sendptr += (SLHEADSIZE + SLRECSIZE);
-	  
-	  /* Return packet */
-	  if ( retpacket )
-	    {
-	      *slpack = (SLpacket *) &slconn->stat->databuf[slconn->stat->sendptr - (SLHEADSIZE + SLRECSIZE)];
-	      return SLPACKET;
-	    }
-	}
-      
-      /* A trap door for terminating, all complete data packets from the buffer
-	 have been sent to the caller */
-      if ( slconn->terminate ) {
-	return SLTERMINATE;
+
+    /* Process data in buffer */
+    while (slconn->stat->recptr - slconn->stat->sendptr >= SLHEADSIZE + SLRECSIZE)
+    {
+      retpacket = 1;
+
+      /* Check for an INFO packet */
+      if (!strncmp (&slconn->stat->databuf[slconn->stat->sendptr], INFOSIGNATURE, 6))
+      {
+        char terminator;
+
+        terminator = (slconn->stat->databuf[slconn->stat->sendptr + SLHEADSIZE - 1] != '*');
+
+        if (!slconn->stat->expect_info)
+        {
+          sl_log_r (slconn, 2, 0, "unexpected INFO packet received, skipping\n");
+        }
+        else
+        {
+          if (terminator)
+          {
+            slconn->stat->expect_info = 0;
+          }
+
+          /* Keep alive packets are not returned */
+          if (slconn->stat->query_mode == KeepAliveQuery)
+          {
+            retpacket = 0;
+
+            if (!terminator)
+            {
+              sl_log_r (slconn, 2, 0, "non-terminated keep-alive packet received!?!\n");
+            }
+            else
+            {
+              sl_log_r (slconn, 1, 2, "keepalive packet received\n");
+            }
+          }
+        }
+
+        if (slconn->stat->query_mode != NoQuery)
+        {
+          slconn->stat->query_mode = NoQuery;
+        }
       }
-      
-      /* After processing the packet buffer shift the data */
-      if ( slconn->stat->sendptr )
-	    {
-	      memmove (slconn->stat->databuf,
-		       &slconn->stat->databuf[slconn->stat->sendptr],
-		       slconn->stat->recptr - slconn->stat->sendptr);
-	      
-	      slconn->stat->recptr -= slconn->stat->sendptr;
-	      slconn->stat->sendptr = 0;
-	    }
-      
-      /* Catch cases where the data stream stopped */
-      if ((slconn->stat->recptr - slconn->stat->sendptr) == 7 &&
-	  !strncmp (&slconn->stat->databuf[slconn->stat->sendptr], "ERROR\r\n", 7))
-	{
-	  sl_log_r (slconn, 2, 0, "SeedLink server reported an error with the last command\n");
-	  slconn->link = sl_disconnect (slconn);
-	  return SLTERMINATE;
-	}
-      
-      if ((slconn->stat->recptr - slconn->stat->sendptr) == 3 &&
-	  !strncmp (&slconn->stat->databuf[slconn->stat->sendptr], "END", 3))
-	{
-	  sl_log_r (slconn, 1, 1, "End of buffer or selected time window\n");
-	  slconn->link = sl_disconnect (slconn);
-	  return SLTERMINATE;
-	}
-      
-      /* Read incoming data if connection is up */
-      if (slconn->stat->sl_state == SL_DATA)
-	{
-	  /* Check for more available data from the socket */
-	  bytesread = 0;
+      else /* Update the stream chain entry if not an INFO packet */
+      {
+        if ((update_stream (slconn, (SLpacket *)&slconn->stat->databuf[slconn->stat->sendptr])) == -1)
+        {
+          /* If updating didn't work the packet is broken */
+          retpacket = 0;
+        }
+      }
 
-	  /* Poll the server */
-	  FD_ZERO (&select_fd);
-	  FD_SET ((unsigned int)slconn->link, &select_fd);
-	  select_tv.tv_sec = 0;
-	  select_tv.tv_usec = 500000;  /* Block up to 0.5 seconds */
+      /* Increment the send pointer */
+      slconn->stat->sendptr += (SLHEADSIZE + SLRECSIZE);
 
-	  select_ret = select ((slconn->link + 1), &select_fd, NULL, NULL, &select_tv);
+      /* Return packet */
+      if (retpacket)
+      {
+        *slpack = (SLpacket *)&slconn->stat->databuf[slconn->stat->sendptr - (SLHEADSIZE + SLRECSIZE)];
+        return SLPACKET;
+      }
+    }
 
-	  /* Check the return from select(), an interrupted system call error
+    /* A trap door for terminating, all complete data packets from the buffer
+	 have been sent to the caller */
+    if (slconn->terminate)
+    {
+      return SLTERMINATE;
+    }
+
+    /* After processing the packet buffer shift the data */
+    if (slconn->stat->sendptr)
+    {
+      memmove (slconn->stat->databuf,
+               &slconn->stat->databuf[slconn->stat->sendptr],
+               slconn->stat->recptr - slconn->stat->sendptr);
+
+      slconn->stat->recptr -= slconn->stat->sendptr;
+      slconn->stat->sendptr = 0;
+    }
+
+    /* Catch cases where the data stream stopped */
+    if ((slconn->stat->recptr - slconn->stat->sendptr) == 7 &&
+        !strncmp (&slconn->stat->databuf[slconn->stat->sendptr], "ERROR\r\n", 7))
+    {
+      sl_log_r (slconn, 2, 0, "SeedLink server reported an error with the last command\n");
+      slconn->link = sl_disconnect (slconn);
+      return SLTERMINATE;
+    }
+
+    if ((slconn->stat->recptr - slconn->stat->sendptr) == 3 &&
+        !strncmp (&slconn->stat->databuf[slconn->stat->sendptr], "END", 3))
+    {
+      sl_log_r (slconn, 1, 1, "End of buffer or selected time window\n");
+      slconn->link = sl_disconnect (slconn);
+      return SLTERMINATE;
+    }
+
+    /* Read incoming data if connection is up */
+    if (slconn->stat->sl_state == SL_DATA)
+    {
+      /* Check for more available data from the socket */
+      bytesread = 0;
+
+      /* Poll the server */
+      FD_ZERO (&select_fd);
+      FD_SET ((unsigned int)slconn->link, &select_fd);
+      select_tv.tv_sec  = 0;
+      select_tv.tv_usec = 500000; /* Block up to 0.5 seconds */
+
+      select_ret = select ((slconn->link + 1), &select_fd, NULL, NULL, &select_tv);
+
+      /* Check the return from select(), an interrupted system call error
 	     will be reported if a signal handler was used.  If the terminate
 	     flag is set this is not an error. */
-	  if (select_ret > 0)
-	    {
-	      if (!FD_ISSET (slconn->link, &select_fd))
-		{
-		  sl_log_r (slconn, 2, 0, "select() reported data but socket not in set!\n");
-		}
-	      else
-		{
-		  bytesread = sl_recvdata (slconn, (void *) &slconn->stat->databuf[slconn->stat->recptr],
-					   BUFSIZE - slconn->stat->recptr, slconn->sladdr);
-		}
-	    }
-	  else if (select_ret < 0 && ! slconn->terminate)
-	    {
-	      sl_log_r (slconn, 2, 0, "select() error: %s\n", slp_strerror ());
-	      slconn->link = sl_disconnect (slconn);
-	      slconn->stat->netdly_trig = -1;
-	    }
+      if (select_ret > 0)
+      {
+        if (!FD_ISSET (slconn->link, &select_fd))
+        {
+          sl_log_r (slconn, 2, 0, "select() reported data but socket not in set!\n");
+        }
+        else
+        {
+          bytesread = sl_recvdata (slconn, (void *)&slconn->stat->databuf[slconn->stat->recptr],
+                                   BUFSIZE - slconn->stat->recptr, slconn->sladdr);
+        }
+      }
+      else if (select_ret < 0 && !slconn->terminate)
+      {
+        sl_log_r (slconn, 2, 0, "select() error: %s\n", slp_strerror ());
+        slconn->link              = sl_disconnect (slconn);
+        slconn->stat->netdly_trig = -1;
+      }
 
-	  if (bytesread < 0)            /* read() failed */
-	    {
-	      slconn->link = sl_disconnect (slconn);
-	      slconn->stat->netdly_trig = -1;
-	    }
-	  else if (bytesread > 0)	/* Data is here, process it */
-	    {
-	      slconn->stat->recptr += bytesread;
+      if (bytesread < 0) /* read() failed */
+      {
+        slconn->link              = sl_disconnect (slconn);
+        slconn->stat->netdly_trig = -1;
+      }
+      else if (bytesread > 0) /* Data is here, process it */
+      {
+        slconn->stat->recptr += bytesread;
 
-	      /* Reset the timeout and keepalive timers */
-	      slconn->stat->netto_trig     = -1;
-	      slconn->stat->keepalive_trig = -1;
-	    }
-	}
+        /* Reset the timeout and keepalive timers */
+        slconn->stat->netto_trig     = -1;
+        slconn->stat->keepalive_trig = -1;
+      }
+    }
 
-      /* Update timing variables */
-      current_time = sl_dtime ();
+    /* Update timing variables */
+    current_time = sl_dtime ();
 
-      /* Network timeout timing logic */
-      if (slconn->netto)
-	{
-	  if (slconn->stat->netto_trig == -1)	/* reset timer */
-	    {
-	      slconn->stat->netto_time = current_time;
-	      slconn->stat->netto_trig = 0;
-	    }
-	  else if (slconn->stat->netto_trig == 0 &&
-		   (current_time - slconn->stat->netto_time) > slconn->netto)
-	    {
-	      slconn->stat->netto_trig = 1;
-	    }
-	}
-      
-      /* Keepalive/heartbeat interval timing logic */
-      if (slconn->keepalive)
-	{
-	  if (slconn->stat->keepalive_trig == -1)	/* reset timer */
-	    {
-	      slconn->stat->keepalive_time = current_time;
-	      slconn->stat->keepalive_trig = 0;
-	    }
-	  else if (slconn->stat->keepalive_trig == 0 &&
-		   (current_time - slconn->stat->keepalive_time) > slconn->keepalive)
-	    {
-	      slconn->stat->keepalive_trig = 1;
-	    }
-	}
-      
-      /* Network delay timing logic */
-      if (slconn->netdly)
-	{
-	  if (slconn->stat->netdly_trig == -1)	/* reset timer */
-	    {
-	      slconn->stat->netdly_time = current_time;
-	      slconn->stat->netdly_trig = 1;
-	    }
-	  else if (slconn->stat->netdly_trig == 1 &&
-		   (current_time - slconn->stat->netdly_time) > slconn->netdly)
-	    {
-	      slconn->stat->netdly_trig = 0;
-	    }
-	}
-    }				/* End of primary loop */
-}  /* End of sl_collect() */
+    /* Network timeout timing logic */
+    if (slconn->netto)
+    {
+      if (slconn->stat->netto_trig == -1) /* reset timer */
+      {
+        slconn->stat->netto_time = current_time;
+        slconn->stat->netto_trig = 0;
+      }
+      else if (slconn->stat->netto_trig == 0 &&
+               (current_time - slconn->stat->netto_time) > slconn->netto)
+      {
+        slconn->stat->netto_trig = 1;
+      }
+    }
 
+    /* Keepalive/heartbeat interval timing logic */
+    if (slconn->keepalive)
+    {
+      if (slconn->stat->keepalive_trig == -1) /* reset timer */
+      {
+        slconn->stat->keepalive_time = current_time;
+        slconn->stat->keepalive_trig = 0;
+      }
+      else if (slconn->stat->keepalive_trig == 0 &&
+               (current_time - slconn->stat->keepalive_time) > slconn->keepalive)
+      {
+        slconn->stat->keepalive_trig = 1;
+      }
+    }
+
+    /* Network delay timing logic */
+    if (slconn->netdly)
+    {
+      if (slconn->stat->netdly_trig == -1) /* reset timer */
+      {
+        slconn->stat->netdly_time = current_time;
+        slconn->stat->netdly_trig = 1;
+      }
+      else if (slconn->stat->netdly_trig == 1 &&
+               (current_time - slconn->stat->netdly_time) > slconn->netdly)
+      {
+        slconn->stat->netdly_trig = 0;
+      }
+    }
+  } /* End of primary loop */
+} /* End of sl_collect() */
 
 /***************************************************************************
  * sl_collect_nb:
@@ -403,11 +402,10 @@ sl_collect (SLCD * slconn, SLpacket ** slpack)
  * Mini-SEED record size.
  ***************************************************************************/
 int
-sl_collect_nb (SLCD * slconn, SLpacket ** slpack)
+sl_collect_nb (SLCD *slconn, SLpacket **slpack)
 {
   return sl_collect_nb_size (slconn, slpack, SLRECSIZE);
 }
-
 
 /***************************************************************************
  * sl_collect_nb_size:
@@ -424,7 +422,7 @@ sl_collect_nb (SLCD * slconn, SLpacket ** slpack)
  * have been received, slpack is set to NULL.  When the connection was
  * closed by the server or the termination sequence completed
  * SLTERMINATE is returned and the slpack pointer is set to NULL.
- * 
+ *
  * 6 Apr 2012 - Jacob Crummey:
  * Added sl_collect_nb_size() to allow for selecting SeedLink record
  * packet size.  Possible values for slrecsize are 128, 256, 512.
@@ -432,336 +430,336 @@ sl_collect_nb (SLCD * slconn, SLpacket ** slpack)
  * checked before passing it to sl_collect_nb_size().
  ***************************************************************************/
 int
-sl_collect_nb_size (SLCD * slconn, SLpacket ** slpack, int slrecsize)
+sl_collect_nb_size (SLCD *slconn, SLpacket **slpack, int slrecsize)
 {
-  int    bytesread;
+  int bytesread;
   double current_time;
-  char   retpacket;
+  char retpacket;
 
   *slpack = NULL;
 
   /* Check if the info was set */
-  if ( slconn->info != NULL )
-    {
-      slconn->stat->query_mode = InfoQuery;
-    }
-  
-  /* If the connection is not up check the SLCD and reset the timing variables */
-  if ( slconn->link == -1 )
-    {
-      if ( sl_checkslcd(slconn) )
-	{
-	  sl_log_r (slconn, 2, 0, "problems with the connection description\n");
-	  return SLTERMINATE;
-	}
+  if (slconn->info != NULL)
+  {
+    slconn->stat->query_mode = InfoQuery;
+  }
 
-      slconn->stat->netto_trig     = -1;	   /* Init net timeout trigger to reset state */
-      slconn->stat->keepalive_trig = -1;	   /* Init keepalive trigger to reset state */
+  /* If the connection is not up check the SLCD and reset the timing variables */
+  if (slconn->link == -1)
+  {
+    if (sl_checkslcd (slconn))
+    {
+      sl_log_r (slconn, 2, 0, "problems with the connection description\n");
+      return SLTERMINATE;
     }
+
+    slconn->stat->netto_trig     = -1; /* Init net timeout trigger to reset state */
+    slconn->stat->keepalive_trig = -1; /* Init keepalive trigger to reset state */
+  }
 
   /* Start the main sequence  */
-  if ( ! slconn->terminate )
+  if (!slconn->terminate)
+  {
+    if (slconn->link == -1)
     {
-      if (slconn->link == -1)
-	{
-	  slconn->stat->sl_state = SL_DOWN;
-	}
-      
-      /* Check for network timeout */
-      if (slconn->stat->sl_state == SL_DATA &&
-	  slconn->netto && slconn->stat->netto_trig > 0)
-	{
-	  sl_log_r (slconn, 1, 0, "network timeout (%ds), reconnecting in %ds\n",
-		    slconn->netto, slconn->netdly);
-	  slconn->link = sl_disconnect (slconn);
-	  slconn->stat->sl_state = SL_DOWN;
-	  slconn->stat->netto_trig = -1;
-	  slconn->stat->netdly_trig = -1;
-	}
-      
-      /* Check if a keepalive packet needs to be sent */
-      if (slconn->stat->sl_state == SL_DATA && !slconn->stat->expect_info &&
-	  slconn->keepalive && slconn->stat->keepalive_trig > 0)
-	{
-	  sl_log_r (slconn, 1, 2, "sending keepalive request\n");
-	  
-	  if ( sl_send_info (slconn, "ID", 3) != -1 )
-	    {
-	      slconn->stat->query_mode = KeepAliveQuery;
-	      slconn->stat->expect_info = 1;
-	      slconn->stat->keepalive_trig = -1;
-	    }
-	}
-      
-      /* Check if an in-stream INFO request needs to be sent */
-      if (slconn->stat->sl_state == SL_DATA &&
-	  !slconn->stat->expect_info && slconn->info)
-	{
-	  if ( sl_send_info (slconn, slconn->info, 1) != -1 )
-	    {
-	      slconn->stat->query_mode = InfoQuery;
-	      slconn->stat->expect_info = 1;
-	    }
-	  else
-	    {
-	      slconn->stat->query_mode = NoQuery;
-	    }
-	  
-	  slconn->info = NULL;
-	}
-      
-      /* Throttle the loop while delaying */
-      if (slconn->stat->sl_state == SL_DOWN && slconn->stat->netdly_trig > 0)
-	{
-	  slp_usleep (500000);
-	}
-      
-      /* Connect to remote SeedLink */
-      if (slconn->stat->sl_state == SL_DOWN && slconn->stat->netdly_trig == 0)
-	{
-	  if (sl_connect (slconn, 1) != -1)
-	    {
-	      slconn->stat->sl_state = SL_UP;
-	    }
-	  slconn->stat->netto_trig = -1;
-	  slconn->stat->netdly_trig = -1;
-	  slconn->stat->keepalive_trig = -1;
-	}
-      
-      /* Negotiate/configure the connection */
-      if (slconn->stat->sl_state == SL_UP)
-	{
-	  int slconfret = 0;
-	  
-	  /* Only send query if a query is set and no streams are defined,
+      slconn->stat->sl_state = SL_DOWN;
+    }
+
+    /* Check for network timeout */
+    if (slconn->stat->sl_state == SL_DATA &&
+        slconn->netto && slconn->stat->netto_trig > 0)
+    {
+      sl_log_r (slconn, 1, 0, "network timeout (%ds), reconnecting in %ds\n",
+                slconn->netto, slconn->netdly);
+      slconn->link              = sl_disconnect (slconn);
+      slconn->stat->sl_state    = SL_DOWN;
+      slconn->stat->netto_trig  = -1;
+      slconn->stat->netdly_trig = -1;
+    }
+
+    /* Check if a keepalive packet needs to be sent */
+    if (slconn->stat->sl_state == SL_DATA && !slconn->stat->expect_info &&
+        slconn->keepalive && slconn->stat->keepalive_trig > 0)
+    {
+      sl_log_r (slconn, 1, 2, "sending keepalive request\n");
+
+      if (sl_send_info (slconn, "ID", 3) != -1)
+      {
+        slconn->stat->query_mode     = KeepAliveQuery;
+        slconn->stat->expect_info    = 1;
+        slconn->stat->keepalive_trig = -1;
+      }
+    }
+
+    /* Check if an in-stream INFO request needs to be sent */
+    if (slconn->stat->sl_state == SL_DATA &&
+        !slconn->stat->expect_info && slconn->info)
+    {
+      if (sl_send_info (slconn, slconn->info, 1) != -1)
+      {
+        slconn->stat->query_mode  = InfoQuery;
+        slconn->stat->expect_info = 1;
+      }
+      else
+      {
+        slconn->stat->query_mode = NoQuery;
+      }
+
+      slconn->info = NULL;
+    }
+
+    /* Throttle the loop while delaying */
+    if (slconn->stat->sl_state == SL_DOWN && slconn->stat->netdly_trig > 0)
+    {
+      slp_usleep (500000);
+    }
+
+    /* Connect to remote SeedLink */
+    if (slconn->stat->sl_state == SL_DOWN && slconn->stat->netdly_trig == 0)
+    {
+      if (sl_connect (slconn, 1) != -1)
+      {
+        slconn->stat->sl_state = SL_UP;
+      }
+      slconn->stat->netto_trig     = -1;
+      slconn->stat->netdly_trig    = -1;
+      slconn->stat->keepalive_trig = -1;
+    }
+
+    /* Negotiate/configure the connection */
+    if (slconn->stat->sl_state == SL_UP)
+    {
+      int slconfret = 0;
+
+      /* Only send query if a query is set and no streams are defined,
 	   * if streams are defined we'll send the query after configuration.
 	   */
-	  if (slconn->info && slconn->streams == NULL)
-	    {
-	      if ( sl_send_info (slconn, slconn->info, 1) != -1 )
-		{
-		  slconn->stat->query_mode = InfoQuery;
-		  slconn->stat->expect_info = 1;
-		}
-	      else
-		{
-		  slconn->stat->query_mode = NoQuery;
-		  slconn->stat->expect_info = 0;
-		}
-	      
-	      slconn->info = NULL;
-	    }
-	  else
-	    {
-	      slconfret = sl_configlink (slconn);
-	      slconn->stat->expect_info = 0;
-	    }
-	  
-	  if (slconfret != -1)
-	    {
-	      slconn->stat->recptr   = 0;	/* initialize the data buffer pointers */
-	      slconn->stat->sendptr  = 0;
-	      slconn->stat->sl_state = SL_DATA;
-	    }
-	  else
-	    {
-	      sl_log_r (slconn, 2, 0, "negotiation with remote SeedLink failed\n");
-	      slconn->link = sl_disconnect (slconn);
-	      slconn->stat->netdly_trig = -1;
-	    }
-	}
-    }
-  else /* We are terminating */
-    {
-      if (slconn->link != -1)
-	{
-	  slconn->link = sl_disconnect (slconn);
-	}
+      if (slconn->info && slconn->streams == NULL)
+      {
+        if (sl_send_info (slconn, slconn->info, 1) != -1)
+        {
+          slconn->stat->query_mode  = InfoQuery;
+          slconn->stat->expect_info = 1;
+        }
+        else
+        {
+          slconn->stat->query_mode  = NoQuery;
+          slconn->stat->expect_info = 0;
+        }
 
-      slconn->stat->sl_state = SL_DATA;
+        slconn->info = NULL;
+      }
+      else
+      {
+        slconfret                 = sl_configlink (slconn);
+        slconn->stat->expect_info = 0;
+      }
+
+      if (slconfret != -1)
+      {
+        slconn->stat->recptr   = 0; /* initialize the data buffer pointers */
+        slconn->stat->sendptr  = 0;
+        slconn->stat->sl_state = SL_DATA;
+      }
+      else
+      {
+        sl_log_r (slconn, 2, 0, "negotiation with remote SeedLink failed\n");
+        slconn->link              = sl_disconnect (slconn);
+        slconn->stat->netdly_trig = -1;
+      }
     }
+  }
+  else /* We are terminating */
+  {
+    if (slconn->link != -1)
+    {
+      slconn->link = sl_disconnect (slconn);
+    }
+
+    slconn->stat->sl_state = SL_DATA;
+  }
 
   /* DEBUG
      sl_log_r (slconn, 1, 0, "link: %d, sendptr: %d, recptr: %d, diff: %d\n",
      slconn->link, slconn->stat->sendptr, slconn->stat->recptr,
      (slconn->stat->recptr - slconn->stat->sendptr) );
   */
-        
+
   /* Process data in buffer */
   while (slconn->stat->recptr - slconn->stat->sendptr >= SLHEADSIZE + slrecsize)
+  {
+    retpacket = 1;
+
+    /* Check for an INFO packet */
+    if (!strncmp (&slconn->stat->databuf[slconn->stat->sendptr], INFOSIGNATURE, 6))
     {
-      retpacket = 1;
-      
-      /* Check for an INFO packet */
-      if (!strncmp (&slconn->stat->databuf[slconn->stat->sendptr], INFOSIGNATURE, 6))
-	{
-	  char terminator;
-	  
-	  terminator = (slconn->stat->databuf[slconn->stat->sendptr + SLHEADSIZE - 1] != '*');
-	  
-	  if ( !slconn->stat->expect_info )
-	    {
-	      sl_log_r (slconn, 2, 0, "unexpected INFO packet received, skipping\n");
-	    }
-	  else
-	    {
-	      if ( terminator )
-		{
-		  slconn->stat->expect_info = 0;
-		}
-	      
-	      /* Keep alive packets are not returned */
-	      if ( slconn->stat->query_mode == KeepAliveQuery )
-		{
-		  retpacket = 0;
-		  
-		  if ( !terminator )
-		    {
-		      sl_log_r (slconn, 2, 0, "non-terminated keep-alive packet received!?!\n");
-		    }
-		  else
-		    {
-		      sl_log_r (slconn, 1, 2, "keepalive packet received\n");
-		    }
-		}
-	    }
-	  
-	  if ( slconn->stat->query_mode != NoQuery )
-	    {
-	      slconn->stat->query_mode = NoQuery;
-	    }
-	}
-      else    /* Update the stream chain entry if not an INFO packet */
-	{
-	  if ( (update_stream (slconn, (SLpacket *) &slconn->stat->databuf[slconn->stat->sendptr])) == -1 )
-	    {
-	      /* If updating didn't work the packet is broken */
-	      retpacket = 0;
-	    }
-	}
-      
-      /* Increment the send pointer */
-      slconn->stat->sendptr += (SLHEADSIZE + slrecsize);
-      
-      /* Return packet */
-      if ( retpacket )
-	{
-	  *slpack = (SLpacket *) &slconn->stat->databuf[slconn->stat->sendptr - (SLHEADSIZE + slrecsize)];
-	  return SLPACKET;
-	}
+      char terminator;
+
+      terminator = (slconn->stat->databuf[slconn->stat->sendptr + SLHEADSIZE - 1] != '*');
+
+      if (!slconn->stat->expect_info)
+      {
+        sl_log_r (slconn, 2, 0, "unexpected INFO packet received, skipping\n");
+      }
+      else
+      {
+        if (terminator)
+        {
+          slconn->stat->expect_info = 0;
+        }
+
+        /* Keep alive packets are not returned */
+        if (slconn->stat->query_mode == KeepAliveQuery)
+        {
+          retpacket = 0;
+
+          if (!terminator)
+          {
+            sl_log_r (slconn, 2, 0, "non-terminated keep-alive packet received!?!\n");
+          }
+          else
+          {
+            sl_log_r (slconn, 1, 2, "keepalive packet received\n");
+          }
+        }
+      }
+
+      if (slconn->stat->query_mode != NoQuery)
+      {
+        slconn->stat->query_mode = NoQuery;
+      }
     }
-  
+    else /* Update the stream chain entry if not an INFO packet */
+    {
+      if ((update_stream (slconn, (SLpacket *)&slconn->stat->databuf[slconn->stat->sendptr])) == -1)
+      {
+        /* If updating didn't work the packet is broken */
+        retpacket = 0;
+      }
+    }
+
+    /* Increment the send pointer */
+    slconn->stat->sendptr += (SLHEADSIZE + slrecsize);
+
+    /* Return packet */
+    if (retpacket)
+    {
+      *slpack = (SLpacket *)&slconn->stat->databuf[slconn->stat->sendptr - (SLHEADSIZE + slrecsize)];
+      return SLPACKET;
+    }
+  }
+
   /* A trap door for terminating, all complete data packets from the buffer
      have been sent to the caller */
-  if ( slconn->terminate ) {
+  if (slconn->terminate)
+  {
     return SLTERMINATE;
   }
-  
+
   /* After processing the packet buffer shift the data */
-  if ( slconn->stat->sendptr )
-    {
-      memmove (slconn->stat->databuf,
-	       &slconn->stat->databuf[slconn->stat->sendptr],
-	       slconn->stat->recptr - slconn->stat->sendptr);
-      
-      slconn->stat->recptr -= slconn->stat->sendptr;
-      slconn->stat->sendptr = 0;
-    }
-  
+  if (slconn->stat->sendptr)
+  {
+    memmove (slconn->stat->databuf,
+             &slconn->stat->databuf[slconn->stat->sendptr],
+             slconn->stat->recptr - slconn->stat->sendptr);
+
+    slconn->stat->recptr -= slconn->stat->sendptr;
+    slconn->stat->sendptr = 0;
+  }
+
   /* Catch cases where the data stream stopped */
   if ((slconn->stat->recptr - slconn->stat->sendptr) == 7 &&
       !strncmp (&slconn->stat->databuf[slconn->stat->sendptr], "ERROR\r\n", 7))
-    {
-      sl_log_r (slconn, 2, 0, "SeedLink server reported an error with the last command\n");
-      slconn->link = sl_disconnect (slconn);
-      return SLTERMINATE;
-    }
-  
+  {
+    sl_log_r (slconn, 2, 0, "SeedLink server reported an error with the last command\n");
+    slconn->link = sl_disconnect (slconn);
+    return SLTERMINATE;
+  }
+
   if ((slconn->stat->recptr - slconn->stat->sendptr) == 3 &&
       !strncmp (&slconn->stat->databuf[slconn->stat->sendptr], "END", 3))
-    {
-      sl_log_r (slconn, 1, 1, "End of buffer or selected time window\n");
-      slconn->link = sl_disconnect (slconn);
-      return SLTERMINATE;
-    }
-  
+  {
+    sl_log_r (slconn, 1, 1, "End of buffer or selected time window\n");
+    slconn->link = sl_disconnect (slconn);
+    return SLTERMINATE;
+  }
+
   /* Process data in our buffer and then read incoming data */
   if (slconn->stat->sl_state == SL_DATA)
+  {
+    /* Check for more available data from the socket */
+    bytesread = 0;
+
+    bytesread = sl_recvdata (slconn, (void *)&slconn->stat->databuf[slconn->stat->recptr],
+                             BUFSIZE - slconn->stat->recptr, slconn->sladdr);
+
+    if (bytesread < 0 && !slconn->terminate) /* read() failed */
     {
-      /* Check for more available data from the socket */
-      bytesread = 0;
-      
-      bytesread = sl_recvdata (slconn, (void *) &slconn->stat->databuf[slconn->stat->recptr],
-			       BUFSIZE - slconn->stat->recptr, slconn->sladdr);
-      
-      if (bytesread < 0 && ! slconn->terminate)            /* read() failed */
-	{
-	  slconn->link = sl_disconnect (slconn);
-	  slconn->stat->netdly_trig = -1;
-	}
-      else if (bytesread > 0)	/* Data is here, process it */
-	{
-	  slconn->stat->recptr += bytesread;
-	  
-	  /* Reset the timeout and keepalive timers */
-	  slconn->stat->netto_trig     = -1;
-	  slconn->stat->keepalive_trig = -1;
-	}
+      slconn->link              = sl_disconnect (slconn);
+      slconn->stat->netdly_trig = -1;
     }
-  
+    else if (bytesread > 0) /* Data is here, process it */
+    {
+      slconn->stat->recptr += bytesread;
+
+      /* Reset the timeout and keepalive timers */
+      slconn->stat->netto_trig     = -1;
+      slconn->stat->keepalive_trig = -1;
+    }
+  }
+
   /* Update timing variables */
   current_time = sl_dtime ();
 
   /* Network timeout timing logic */
   if (slconn->netto)
+  {
+    if (slconn->stat->netto_trig == -1) /* reset timer */
     {
-      if (slconn->stat->netto_trig == -1)	/* reset timer */
-	{
-	  slconn->stat->netto_time = current_time;
-	  slconn->stat->netto_trig = 0;
-	}
-      else if (slconn->stat->netto_trig == 0 &&
-	       (current_time - slconn->stat->netto_time) > slconn->netto)
-	{
-	  slconn->stat->netto_trig = 1;
-	}
+      slconn->stat->netto_time = current_time;
+      slconn->stat->netto_trig = 0;
     }
-  
+    else if (slconn->stat->netto_trig == 0 &&
+             (current_time - slconn->stat->netto_time) > slconn->netto)
+    {
+      slconn->stat->netto_trig = 1;
+    }
+  }
+
   /* Keepalive/heartbeat interval timing logic */
   if (slconn->keepalive)
+  {
+    if (slconn->stat->keepalive_trig == -1) /* reset timer */
     {
-      if (slconn->stat->keepalive_trig == -1)	/* reset timer */
-	{
-	  slconn->stat->keepalive_time = current_time;
-	  slconn->stat->keepalive_trig = 0;
-	}
-      else if (slconn->stat->keepalive_trig == 0 &&
-	       (current_time - slconn->stat->keepalive_time) > slconn->keepalive)
-	{
-	  slconn->stat->keepalive_trig = 1;
-	}
+      slconn->stat->keepalive_time = current_time;
+      slconn->stat->keepalive_trig = 0;
     }
-  
+    else if (slconn->stat->keepalive_trig == 0 &&
+             (current_time - slconn->stat->keepalive_time) > slconn->keepalive)
+    {
+      slconn->stat->keepalive_trig = 1;
+    }
+  }
+
   /* Network delay timing logic */
   if (slconn->netdly)
+  {
+    if (slconn->stat->netdly_trig == -1) /* reset timer */
     {
-      if (slconn->stat->netdly_trig == -1)	/* reset timer */
-	{
-	  slconn->stat->netdly_time = current_time;
-	  slconn->stat->netdly_trig = 1;
-	}
-      else if (slconn->stat->netdly_trig == 1 &&
-	       (current_time - slconn->stat->netdly_time) > slconn->netdly)
-	{
-	  slconn->stat->netdly_trig = 0;
-	}
+      slconn->stat->netdly_time = current_time;
+      slconn->stat->netdly_trig = 1;
     }
-  
+    else if (slconn->stat->netdly_trig == 1 &&
+             (current_time - slconn->stat->netdly_time) > slconn->netdly)
+    {
+      slconn->stat->netdly_trig = 0;
+    }
+  }
+
   /* Non-blocking and no data was returned */
   return SLNOPACKET;
-  
-}  /* End of sl_collect_nb() */
 
+} /* End of sl_collect_nb() */
 
 /***************************************************************************
  * update_stream:
@@ -772,111 +770,110 @@ sl_collect_nb_size (SLCD * slconn, SLpacket ** slpack, int slrecsize)
  * Returns 0 if successfully updated and -1 if not found or error.
  ***************************************************************************/
 int
-update_stream (SLCD * slconn, SLpacket * slpack)
+update_stream (SLCD *slconn, SLpacket *slpack)
 {
   SLstream *curstream;
   struct sl_fsdh_s fsdh;
   int seqnum;
   int swapflag = 0;
-  int updates = 0;
+  int updates  = 0;
   char net[3];
   char sta[6];
-  
-  if ( (seqnum = sl_sequence (slpack)) == -1 )
-    {
-      sl_log_r (slconn, 2, 0, "update_stream(): could not determine sequence number\n");
-      return -1;
-    }
-  
+
+  if ((seqnum = sl_sequence (slpack)) == -1)
+  {
+    sl_log_r (slconn, 2, 0, "update_stream(): could not determine sequence number\n");
+    return -1;
+  }
+
   /* Copy fixed header */
-  memcpy (&fsdh, &slpack->msrecord, sizeof(struct sl_fsdh_s));
-  
+  memcpy (&fsdh, &slpack->msrecord, sizeof (struct sl_fsdh_s));
+
   /* Check to see if byte swapping is needed (bogus year makes good test) */
   if ((fsdh.start_time.year < 1900) || (fsdh.start_time.year > 2050))
     swapflag = 1;
-  
-  /* Change byte order? */
-  if ( swapflag )
-    {
-      sl_gswap2 (&fsdh.start_time.year);
-      sl_gswap2 (&fsdh.start_time.day);
-    }
-  
-  curstream = slconn->streams;
-  
-  /* Generate some "clean" net and sta strings */
-  if ( curstream != NULL )
-    {
-      sl_strncpclean (net, fsdh.network, 2);
-      sl_strncpclean (sta, fsdh.station, 5);
-    }
-  
-  /* For uni-station mode */
-  if ( curstream != NULL )
-    {
-      if ( strcmp (curstream->net, UNINETWORK) == 0 &&
-	   strcmp (curstream->sta, UNISTATION) == 0 )
-	{
-	  int month = 0;
-	  int mday = 0;
-	  
-	  sl_doy2md (fsdh.start_time.year,
-		     fsdh.start_time.day,
-		     &month, &mday);
-	  
-	  curstream->seqnum = seqnum;
-	  
-	  snprintf (curstream->timestamp, 20,
-		    "%04d,%02d,%02d,%02d,%02d,%02d",
-		    fsdh.start_time.year,
-		    month,
-		    mday,
-		    fsdh.start_time.hour,
-		    fsdh.start_time.min,
-		    fsdh.start_time.sec);
-	  
-	  return 0;
-	}
-    }
-  
-  /* For multi-station mode, search the stream chain and update all matching entries */
-  while ( curstream != NULL )
-    {
-      /* Use glob matching to match wildcarded network and station codes */
-      if ( sl_globmatch (net, curstream->net) &&
-	   sl_globmatch (sta, curstream->sta) )
-        {
-	  int month = 0;
-	  int mday = 0;
-	  
-	  sl_doy2md (fsdh.start_time.year,
-		     fsdh.start_time.day,
-		     &month, &mday);
-	  
-	  curstream->seqnum = seqnum;
-	  
-	  snprintf (curstream->timestamp, 20,
-		    "%04d,%02d,%02d,%02d,%02d,%02d",
-		    fsdh.start_time.year,
-		    month,
-		    mday,
-		    fsdh.start_time.hour,
-		    fsdh.start_time.min,
-		    fsdh.start_time.sec);
-	  
-	  updates++;
-        }
-      
-      curstream = curstream->next;
-    }
-  
-  /* If no updates then no match was found */
-  if ( updates == 0 )
-    sl_log_r (slconn, 2, 0, "unexpected data received: %.2s %.6s\n", net, sta);
-  
-  return (updates == 0) ? -1 : 0;
-}  /* End of update_stream() */
 
+  /* Change byte order? */
+  if (swapflag)
+  {
+    sl_gswap2 (&fsdh.start_time.year);
+    sl_gswap2 (&fsdh.start_time.day);
+  }
+
+  curstream = slconn->streams;
+
+  /* Generate some "clean" net and sta strings */
+  if (curstream != NULL)
+  {
+    sl_strncpclean (net, fsdh.network, 2);
+    sl_strncpclean (sta, fsdh.station, 5);
+  }
+
+  /* For uni-station mode */
+  if (curstream != NULL)
+  {
+    if (strcmp (curstream->net, UNINETWORK) == 0 &&
+        strcmp (curstream->sta, UNISTATION) == 0)
+    {
+      int month = 0;
+      int mday  = 0;
+
+      sl_doy2md (fsdh.start_time.year,
+                 fsdh.start_time.day,
+                 &month, &mday);
+
+      curstream->seqnum = seqnum;
+
+      snprintf (curstream->timestamp, 20,
+                "%04d,%02d,%02d,%02d,%02d,%02d",
+                fsdh.start_time.year,
+                month,
+                mday,
+                fsdh.start_time.hour,
+                fsdh.start_time.min,
+                fsdh.start_time.sec);
+
+      return 0;
+    }
+  }
+
+  /* For multi-station mode, search the stream chain and update all matching entries */
+  while (curstream != NULL)
+  {
+    /* Use glob matching to match wildcarded network and station codes */
+    if (sl_globmatch (net, curstream->net) &&
+        sl_globmatch (sta, curstream->sta))
+    {
+      int month = 0;
+      int mday  = 0;
+
+      sl_doy2md (fsdh.start_time.year,
+                 fsdh.start_time.day,
+                 &month, &mday);
+
+      curstream->seqnum = seqnum;
+
+      snprintf (curstream->timestamp, 20,
+                "%04d,%02d,%02d,%02d,%02d,%02d",
+                fsdh.start_time.year,
+                month,
+                mday,
+                fsdh.start_time.hour,
+                fsdh.start_time.min,
+                fsdh.start_time.sec);
+
+      updates++;
+    }
+
+    curstream = curstream->next;
+  }
+
+  /* If no updates then no match was found */
+  if (updates == 0)
+    sl_log_r (slconn, 2, 0, "unexpected data received: %.2s %.6s\n", net, sta);
+
+  return (updates == 0) ? -1 : 0;
+} /* End of update_stream() */
 
 /***************************************************************************
  * sl_newslcd:
@@ -888,50 +885,50 @@ update_stream (SLCD * slconn, SLpacket * slpack)
 SLCD *
 sl_newslcd (void)
 {
-  SLCD * slconn;
+  SLCD *slconn;
 
-  slconn = (SLCD *) malloc (sizeof(SLCD));
+  slconn = (SLCD *)malloc (sizeof (SLCD));
 
-  if ( slconn == NULL )
-    {
-      sl_log_r (NULL, 2, 0, "new_slconn(): error allocating memory\n");
-      return NULL;
-    }
+  if (slconn == NULL)
+  {
+    sl_log_r (NULL, 2, 0, "new_slconn(): error allocating memory\n");
+    return NULL;
+  }
 
   /* Set defaults */
-  slconn->streams        = NULL;
-  slconn->sladdr         = NULL;
-  slconn->begin_time     = NULL;
-  slconn->end_time       = NULL;
+  slconn->streams    = NULL;
+  slconn->sladdr     = NULL;
+  slconn->begin_time = NULL;
+  slconn->end_time   = NULL;
 
-  slconn->resume         = 1;
-  slconn->multistation   = 0;
-  slconn->dialup         = 0;
-  slconn->batchmode      = 0;
-  slconn->lastpkttime    = 0;
-  slconn->terminate      = 0;
-  
-  slconn->keepalive      = 0;
-  slconn->netto          = 600;
-  slconn->netdly         = 30;
-  
-  slconn->link           = -1;
-  slconn->info           = NULL;
-  slconn->protocol_ver   = 0.0;
+  slconn->resume       = 1;
+  slconn->multistation = 0;
+  slconn->dialup       = 0;
+  slconn->batchmode    = 0;
+  slconn->lastpkttime  = 1;
+  slconn->terminate    = 0;
+
+  slconn->keepalive = 0;
+  slconn->netto     = 600;
+  slconn->netdly    = 30;
+
+  slconn->link         = -1;
+  slconn->info         = NULL;
+  slconn->protocol_ver = 0.0;
 
   /* Allocate the associated persistent state struct */
-  slconn->stat = (SLstat *) malloc (sizeof(SLstat));
-  
-  if ( slconn->stat == NULL )
-    {
-      sl_log_r (NULL, 2, 0, "new_slconn(): error allocating memory\n");
-      free (slconn);
-      return NULL;
-    }
+  slconn->stat = (SLstat *)malloc (sizeof (SLstat));
 
-  slconn->stat->recptr         = 0;
-  slconn->stat->sendptr        = 0;
-  slconn->stat->expect_info    = 0;
+  if (slconn->stat == NULL)
+  {
+    sl_log_r (NULL, 2, 0, "new_slconn(): error allocating memory\n");
+    free (slconn);
+    return NULL;
+  }
+
+  slconn->stat->recptr      = 0;
+  slconn->stat->sendptr     = 0;
+  slconn->stat->expect_info = 0;
 
   slconn->stat->netto_trig     = -1;
   slconn->stat->netdly_trig    = 0;
@@ -941,24 +938,23 @@ sl_newslcd (void)
   slconn->stat->netdly_time    = 0.0;
   slconn->stat->keepalive_time = 0.0;
 
-  slconn->stat->sl_state       = SL_DOWN;
-  slconn->stat->query_mode     = NoQuery;
+  slconn->stat->sl_state   = SL_DOWN;
+  slconn->stat->query_mode = NoQuery;
 
   slconn->log = NULL;
 
   return slconn;
-}  /* End of sl_newslconn() */
-
+} /* End of sl_newslconn() */
 
 /***************************************************************************
  * sl_freeslcd:
  *
- * Free all memory associated with a SLCD struct including the 
+ * Free all memory associated with a SLCD struct including the
  * associated stream chain and persistent connection state.
  *
  ***************************************************************************/
 void
-sl_freeslcd (SLCD * slconn)
+sl_freeslcd (SLCD *slconn)
 {
   SLstream *curstream;
   SLstream *nextstream;
@@ -967,34 +963,33 @@ sl_freeslcd (SLCD * slconn)
 
   /* Traverse the stream chain and free memory */
   while (curstream != NULL)
-    {
-      nextstream = curstream->next;
+  {
+    nextstream = curstream->next;
 
-      if ( curstream->selectors != NULL )
-	free (curstream->selectors);
-      free (curstream);
+    if (curstream->selectors != NULL)
+      free (curstream->selectors);
+    free (curstream);
 
-      curstream = nextstream;
-    }
+    curstream = nextstream;
+  }
 
-  if ( slconn->sladdr != NULL )
+  if (slconn->sladdr != NULL)
     free (slconn->sladdr);
 
-  if ( slconn->begin_time != NULL )
+  if (slconn->begin_time != NULL)
     free (slconn->begin_time);
 
-  if ( slconn->end_time != NULL )
+  if (slconn->end_time != NULL)
     free (slconn->end_time);
 
-  if ( slconn->stat != NULL )
+  if (slconn->stat != NULL)
     free (slconn->stat);
 
-  if ( slconn->log != NULL )
+  if (slconn->log != NULL)
     free (slconn->log);
 
-  free (slconn);  
-}  /* End of sl_freeslcd() */
-
+  free (slconn);
+} /* End of sl_freeslcd() */
 
 /***************************************************************************
  * sl_addstream:
@@ -1009,73 +1004,72 @@ sl_freeslcd (SLCD * slconn)
  * Returns 0 if successfully added or -1 on error.
  ***************************************************************************/
 int
-sl_addstream (SLCD * slconn, const char * net, const char * sta,
-	      const char * selectors, int seqnum,
-	      const char * timestamp)
+sl_addstream (SLCD *slconn, const char *net, const char *sta,
+              const char *selectors, int seqnum,
+              const char *timestamp)
 {
   SLstream *curstream;
   SLstream *newstream;
   SLstream *laststream = NULL;
-  
+
   curstream = slconn->streams;
-  
+
   /* Sanity, check for a uni-station mode entry */
-  if ( curstream )
+  if (curstream)
+  {
+    if (strcmp (curstream->net, UNINETWORK) == 0 &&
+        strcmp (curstream->sta, UNISTATION) == 0)
     {
-      if ( strcmp (curstream->net, UNINETWORK) == 0 &&
-	   strcmp (curstream->sta, UNISTATION) == 0 )
-	{
-	  sl_log_r (slconn, 2, 0, "sl_addstream(): uni-station mode already configured!\n");
-	  return -1;
-	}
-    }
-  
-  /* Search the stream chain */
-  while ( curstream != NULL )
-    {
-      laststream = curstream;
-      curstream = curstream->next;
-    }
-  
-  newstream = (SLstream *) malloc (sizeof(SLstream));
-  
-  if ( newstream == NULL )
-    {
-      sl_log_r (slconn, 2, 0, "sl_addstream(): error allocating memory\n");
+      sl_log_r (slconn, 2, 0, "sl_addstream(): uni-station mode already configured!\n");
       return -1;
     }
-  
-  newstream->net = strdup(net);
-  newstream->sta = strdup(sta);
+  }
 
-  if ( selectors == 0 || selectors == NULL )
+  /* Search the stream chain */
+  while (curstream != NULL)
+  {
+    laststream = curstream;
+    curstream  = curstream->next;
+  }
+
+  newstream = (SLstream *)malloc (sizeof (SLstream));
+
+  if (newstream == NULL)
+  {
+    sl_log_r (slconn, 2, 0, "sl_addstream(): error allocating memory\n");
+    return -1;
+  }
+
+  newstream->net = strdup (net);
+  newstream->sta = strdup (sta);
+
+  if (selectors == 0 || selectors == NULL)
     newstream->selectors = 0;
   else
-    newstream->selectors = strdup(selectors);
+    newstream->selectors = strdup (selectors);
 
   newstream->seqnum = seqnum;
 
-  if ( timestamp == 0 || timestamp == NULL )
+  if (timestamp == 0 || timestamp == NULL)
     newstream->timestamp[0] = '\0';
   else
-    strncpy(newstream->timestamp, timestamp, 20);
+    strncpy (newstream->timestamp, timestamp, 20);
 
   newstream->next = NULL;
-  
-  if ( slconn->streams == NULL )
-    {
-      slconn->streams = newstream;
-    }
-  else if ( laststream )
-    {
-      laststream->next = newstream;
-    }  
+
+  if (slconn->streams == NULL)
+  {
+    slconn->streams = newstream;
+  }
+  else if (laststream)
+  {
+    laststream->next = newstream;
+  }
 
   slconn->multistation = 1;
 
   return 0;
-}  /* End of sl_addstream() */
-
+} /* End of sl_addstream() */
 
 /***************************************************************************
  * sl_setuniparams:
@@ -1092,54 +1086,53 @@ sl_addstream (SLCD * slconn, const char * net, const char * sta,
  * Returns 0 if successfully added or -1 on error.
  ***************************************************************************/
 int
-sl_setuniparams (SLCD * slconn, const char * selectors,
-		 int seqnum, const char * timestamp)
+sl_setuniparams (SLCD *slconn, const char *selectors,
+                 int seqnum, const char *timestamp)
 {
   SLstream *newstream;
 
   newstream = slconn->streams;
 
-  if ( newstream == NULL )
-    {
-      newstream = (SLstream *) malloc (sizeof(SLstream));
+  if (newstream == NULL)
+  {
+    newstream = (SLstream *)malloc (sizeof (SLstream));
 
-      if ( newstream == NULL )
-	{
-	  sl_log_r (slconn, 2, 0, "sl_setuniparams(): error allocating memory\n");
-	  return -1;
-	}
-    }
-  else if ( strcmp (newstream->net, UNINETWORK) != 0 ||
-	    strcmp (newstream->sta, UNISTATION) != 0)
+    if (newstream == NULL)
     {
-      sl_log_r (slconn, 2, 0, "sl_setuniparams(): multi-station mode already configured!\n");
+      sl_log_r (slconn, 2, 0, "sl_setuniparams(): error allocating memory\n");
       return -1;
     }
+  }
+  else if (strcmp (newstream->net, UNINETWORK) != 0 ||
+           strcmp (newstream->sta, UNISTATION) != 0)
+  {
+    sl_log_r (slconn, 2, 0, "sl_setuniparams(): multi-station mode already configured!\n");
+    return -1;
+  }
 
   newstream->net = UNINETWORK;
   newstream->sta = UNISTATION;
 
-  if ( selectors == 0 || selectors == NULL )
+  if (selectors == 0 || selectors == NULL)
     newstream->selectors = 0;
   else
-    newstream->selectors = strdup(selectors);
+    newstream->selectors = strdup (selectors);
 
   newstream->seqnum = seqnum;
 
-  if ( timestamp == 0 || timestamp == NULL )
+  if (timestamp == 0 || timestamp == NULL)
     newstream->timestamp[0] = '\0';
   else
-    strncpy(newstream->timestamp, timestamp, 20);
+    strncpy (newstream->timestamp, timestamp, 20);
 
   newstream->next = NULL;
-  
+
   slconn->streams = newstream;
-  
+
   slconn->multistation = 0;
 
   return 0;
-}  /* End of sl_setuniparams() */
-
+} /* End of sl_setuniparams() */
 
 /***************************************************************************
  * sl_request_info:
@@ -1149,21 +1142,20 @@ sl_setuniparams (SLCD * slconn, const char * selectors,
  * Returns 0 if successful and -1 if error.
  ***************************************************************************/
 int
-sl_request_info (SLCD * slconn, const char * infostr)
+sl_request_info (SLCD *slconn, const char *infostr)
 {
-  if ( slconn->info != NULL )
-    {
-      sl_log_r (slconn, 2, 0, "Cannot make '%.15s' INFO request, one is already pending\n",
-		infostr);
-      return -1;
-    }
+  if (slconn->info != NULL)
+  {
+    sl_log_r (slconn, 2, 0, "Cannot make '%.15s' INFO request, one is already pending\n",
+              infostr);
+    return -1;
+  }
   else
-    {
-      slconn->info = infostr;
-      return 0;
-    }
-}  /* End of sl_request_info() */
-
+  {
+    slconn->info = infostr;
+    return 0;
+  }
+} /* End of sl_request_info() */
 
 /***************************************************************************
  * sl_sequence:
@@ -1174,27 +1166,26 @@ sl_request_info (SLCD * slconn, const char * infostr)
  *   0 for INFO packets or -1 on error.
  ***************************************************************************/
 int
-sl_sequence (const SLpacket * slpack)
+sl_sequence (const SLpacket *slpack)
 {
   int seqnum;
   char seqstr[7], *sqtail;
 
-  if ( strncmp (slpack->slhead, SIGNATURE, 2) )
+  if (strncmp (slpack->slhead, SIGNATURE, 2))
     return -1;
 
-  if ( !strncmp (slpack->slhead, INFOSIGNATURE, 6) )
+  if (!strncmp (slpack->slhead, INFOSIGNATURE, 6))
     return 0;
 
   strncpy (seqstr, &slpack->slhead[2], 6);
   seqstr[6] = '\0';
-  seqnum = strtoul (seqstr, &sqtail, 16);
+  seqnum    = strtoul (seqstr, &sqtail, 16);
 
-  if ( seqnum & ~0xffffff || *sqtail )
+  if (seqnum & ~0xffffff || *sqtail)
     return -1;
 
   return seqnum;
-}  /* End of sl_sequence() */
-
+} /* End of sl_sequence() */
 
 /***************************************************************************
  * sl_packettype:
@@ -1206,76 +1197,74 @@ sl_sequence (const SLpacket * slpack)
  * Returns the packet type; defined in libslink.h.
  ***************************************************************************/
 int
-sl_packettype (const SLpacket * slpack)
+sl_packettype (const SLpacket *slpack)
 {
   int b2000 = 0;
   struct sl_fsdh_s *fsdh;
 
-  uint16_t  num_samples;
-  int16_t   samprate_fact;
-  int16_t   begin_blockette;
-  uint16_t  blkt_type;
-  uint16_t  next_blkt;
+  uint16_t num_samples;
+  int16_t samprate_fact;
+  int16_t begin_blockette;
+  uint16_t blkt_type;
+  uint16_t next_blkt;
 
   const struct sl_blkt_head_s *p;
-  fsdh = (struct sl_fsdh_s *) &slpack->msrecord;
+  fsdh = (struct sl_fsdh_s *)&slpack->msrecord;
 
   /* Check for an INFO packet */
-  if ( !strncmp (slpack->slhead, INFOSIGNATURE, 6) )
-    {
-      /* Check if it is terminated */
-      if  (slpack->slhead[SLHEADSIZE - 1] != '*')
-	return SLINFT;
-      else
-	return SLINF;
-    }  
+  if (!strncmp (slpack->slhead, INFOSIGNATURE, 6))
+  {
+    /* Check if it is terminated */
+    if (slpack->slhead[SLHEADSIZE - 1] != '*')
+      return SLINFT;
+    else
+      return SLINF;
+  }
 
-  num_samples     = (uint16_t) ntohs(fsdh->num_samples);
-  samprate_fact   = (int16_t)  ntohs(fsdh->samprate_fact);
-  begin_blockette = (int16_t)  ntohs(fsdh->begin_blockette);
+  num_samples     = (uint16_t)ntohs (fsdh->num_samples);
+  samprate_fact   = (int16_t)ntohs (fsdh->samprate_fact);
+  begin_blockette = (int16_t)ntohs (fsdh->begin_blockette);
 
-  p = (const struct sl_blkt_head_s *) ((const char *) fsdh + 
-				       begin_blockette);
+  p = (const struct sl_blkt_head_s *)((const char *)fsdh +
+                                      begin_blockette);
 
-  blkt_type       = (uint16_t) ntohs(p->blkt_type);
-  next_blkt       = (uint16_t) ntohs(p->next_blkt);
+  blkt_type = (uint16_t)ntohs (p->blkt_type);
+  next_blkt = (uint16_t)ntohs (p->next_blkt);
 
   do
+  {
+    if (((const char *)p) - ((const char *)fsdh) >
+        MAX_HEADER_SIZE)
     {
-      if (((const char *) p) - ((const char *) fsdh) >
-	  MAX_HEADER_SIZE)
-	{
-	  return SLNUM;
-	}
-
-      if (blkt_type >= 200 && blkt_type <= 299)
-	return SLDET;
-      if (blkt_type >= 300 && blkt_type <= 399)
-	return SLCAL;
-      if (blkt_type >= 500 && blkt_type <= 599)
-	return SLTIM;
-      if (blkt_type == 2000)
-	b2000 = 1;
-
-      p = (const struct sl_blkt_head_s *) ((const char *) fsdh +
-				    next_blkt);
-      
-      blkt_type       = (uint16_t) ntohs(p->blkt_type);
-      next_blkt       = (uint16_t) ntohs(p->next_blkt);
+      return SLNUM;
     }
-  while ((const struct sl_fsdh_s *) p != fsdh);
+
+    if (blkt_type >= 200 && blkt_type <= 299)
+      return SLDET;
+    if (blkt_type >= 300 && blkt_type <= 399)
+      return SLCAL;
+    if (blkt_type >= 500 && blkt_type <= 599)
+      return SLTIM;
+    if (blkt_type == 2000)
+      b2000 = 1;
+
+    p = (const struct sl_blkt_head_s *)((const char *)fsdh +
+                                        next_blkt);
+
+    blkt_type = (uint16_t)ntohs (p->blkt_type);
+    next_blkt = (uint16_t)ntohs (p->next_blkt);
+  } while ((const struct sl_fsdh_s *)p != fsdh);
 
   if (samprate_fact == 0)
-    {
-      if (num_samples != 0)
-	return SLMSG;
-      if (b2000)
-	return SLBLK;
-    }
+  {
+    if (num_samples != 0)
+      return SLMSG;
+    if (b2000)
+      return SLBLK;
+  }
 
   return SLDATA;
-}  /* End of sl_packettype() */
-
+} /* End of sl_packettype() */
 
 /***************************************************************************
  * sl_terminate:
@@ -1283,9 +1272,9 @@ sl_packettype (const SLpacket * slpack)
  * Set the terminate flag in the SLCD.
  ***************************************************************************/
 void
-sl_terminate (SLCD * slconn)
+sl_terminate (SLCD *slconn)
 {
   sl_log_r (slconn, 1, 1, "Terminating connection\n");
 
   slconn->terminate = 1;
-}  /* End of sl_terminate() */
+} /* End of sl_terminate() */

--- a/bin/rt/slink2orb/libslink/statefile.c
+++ b/bin/rt/slink2orb/libslink/statefile.c
@@ -8,12 +8,11 @@
  * modified: 2008.028
  ***************************************************************************/
 
-#include <stdio.h>
 #include <errno.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "libslink.h"
-
 
 /***************************************************************************
  * sl_savestate:
@@ -26,49 +25,48 @@
  *  0 : completed successfully
  ***************************************************************************/
 int
-sl_savestate (SLCD * slconn, const char *statefile)
+sl_savestate (SLCD *slconn, const char *statefile)
 {
   SLstream *curstream;
   char line[100];
   int linelen;
   int statefd;
-  
+
   curstream = slconn->streams;
-  
+
   /* Open the state file */
-  if ( (statefd = slp_openfile (statefile, 'w')) < 0 )
-    {
-      sl_log_r (slconn, 2, 0, "cannot open state file for writing\n");
-      return -1;
-    }
-  
+  if ((statefd = slp_openfile (statefile, 'w')) < 0)
+  {
+    sl_log_r (slconn, 2, 0, "cannot open state file for writing\n");
+    return -1;
+  }
+
   sl_log_r (slconn, 1, 2, "saving connection state to state file\n");
-  
+
   /* Traverse stream chain and write sequence numbers */
-  while ( curstream != NULL )
+  while (curstream != NULL)
+  {
+    linelen = snprintf (line, sizeof (line), "%s %s %d %s\n",
+                        curstream->net, curstream->sta,
+                        curstream->seqnum, curstream->timestamp);
+
+    if (write (statefd, line, linelen) != linelen)
     {
-      linelen = snprintf (line, sizeof(line), "%s %s %d %s\n",
-			  curstream->net, curstream->sta,
-			  curstream->seqnum, curstream->timestamp);
-      
-      if ( write (statefd, line, linelen) != linelen )
-	{
-	  sl_log_r (slconn, 2, 0, "cannot write to state file, %s\n", strerror (errno));
-	  return -1;
-	}
-      
-      curstream = curstream->next;
-    }
-  
-  if ( close (statefd) )
-    {
-      sl_log_r (slconn, 2, 0, "cannot close state file, %s\n", strerror (errno));
+      sl_log_r (slconn, 2, 0, "cannot write to state file, %s\n", strerror (errno));
       return -1;
     }
-  
+
+    curstream = curstream->next;
+  }
+
+  if (close (statefd))
+  {
+    sl_log_r (slconn, 2, 0, "cannot close state file, %s\n", strerror (errno));
+    return -1;
+  }
+
   return 0;
 } /* End of sl_savestate() */
-
 
 /***************************************************************************
  * sl_recoverstate:
@@ -82,7 +80,7 @@ sl_savestate (SLCD * slconn, const char *statefile)
  *  1 : file could not be opened (probably not found)
  ***************************************************************************/
 int
-sl_recoverstate (SLCD * slconn, const char *statefile)
+sl_recoverstate (SLCD *slconn, const char *statefile)
 {
   SLstream *curstream;
   int statefd;
@@ -94,68 +92,68 @@ sl_recoverstate (SLCD * slconn, const char *statefile)
   int fields;
   int count;
 
-  net[0] = '\0';
-  sta[0] = '\0';
+  net[0]       = '\0';
+  sta[0]       = '\0';
   timestamp[0] = '\0';
 
   /* Open the state file */
-  if ( (statefd = slp_openfile (statefile, 'r')) < 0 )
+  if ((statefd = slp_openfile (statefile, 'r')) < 0)
+  {
+    if (errno == ENOENT)
     {
-      if (errno == ENOENT)
-	{
-	  sl_log_r (slconn, 1, 0, "could not find state file: %s\n", statefile);
-	  return 1;
-	}
-      else
-	{
-	  sl_log_r (slconn, 2, 0, "could not open state file, %s\n", strerror (errno));
-	  return -1;
-	}
+      sl_log_r (slconn, 1, 0, "could not find state file: %s\n", statefile);
+      return 1;
     }
-  
-  sl_log_r (slconn, 1, 1, "recovering connection state from state file\n");
-  
-  count = 1;
-  
-  while ( (sl_readline (statefd, line, sizeof(line))) >= 0 )
+    else
     {
-      fields = sscanf (line, "%2s %5s %d %19[0-9,]\n",
-		       net, sta, &seqnum, timestamp);
-      
-      if ( fields < 0 )
-        continue;
-      
-      if ( fields < 3 )
-	{
-	  sl_log_r (slconn, 2, 0, "could not parse line %d of state file\n", count);
-	}
-      
-      /* Search for a matching NET and STA in the stream chain */
-      curstream = slconn->streams;
-      while ( curstream != NULL )
-	{
-	  if ( !strcmp (net, curstream->net) &&
-	       !strcmp (sta, curstream->sta) )
-	    {
-	      curstream->seqnum = seqnum;
-
-	      if ( fields == 4 )
-		strncpy (curstream->timestamp, timestamp, 20);
-	      
-	      break;
-	    }
-
-	  curstream = curstream->next;
-	}
-
-      count++;
-    }
-
-  if ( close (statefd) )
-    {
-      sl_log_r (slconn, 2, 0, "could not close state file, %s\n", strerror (errno));
+      sl_log_r (slconn, 2, 0, "could not open state file, %s\n", strerror (errno));
       return -1;
     }
-  
+  }
+
+  sl_log_r (slconn, 1, 1, "recovering connection state from state file\n");
+
+  count = 1;
+
+  while ((sl_readline (statefd, line, sizeof (line))) >= 0)
+  {
+    fields = sscanf (line, "%2s %5s %d %19[0-9,]\n",
+                     net, sta, &seqnum, timestamp);
+
+    if (fields < 0)
+      continue;
+
+    if (fields < 3)
+    {
+      sl_log_r (slconn, 2, 0, "could not parse line %d of state file\n", count);
+    }
+
+    /* Search for a matching NET and STA in the stream chain */
+    curstream = slconn->streams;
+    while (curstream != NULL)
+    {
+      if (!strcmp (net, curstream->net) &&
+          !strcmp (sta, curstream->sta))
+      {
+        curstream->seqnum = seqnum;
+
+        if (fields == 4)
+          strncpy (curstream->timestamp, timestamp, 20);
+
+        break;
+      }
+
+      curstream = curstream->next;
+    }
+
+    count++;
+  }
+
+  if (close (statefd))
+  {
+    sl_log_r (slconn, 2, 0, "could not close state file, %s\n", strerror (errno));
+    return -1;
+  }
+
   return 0;
 } /* End of sl_recoverstate() */

--- a/bin/rt/slink2orb/libslink/strutils.c
+++ b/bin/rt/slink2orb/libslink/strutils.c
@@ -8,15 +8,14 @@
  * modified: 2006.344
  ***************************************************************************/
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
 #include "libslink.h"
-
 
 /***************************************************************************
  * sl_strparse:
@@ -34,9 +33,9 @@
 int
 sl_strparse (const char *string, const char *delim, SLstrlist **list)
 {
-  const char *beg;			/* beginning of element */
-  const char *del;			/* delimiter */
-  int stop = 0;
+  const char *beg; /* beginning of element */
+  const char *del; /* delimiter */
+  int stop  = 0;
   int count = 0;
   int total;
 
@@ -44,66 +43,65 @@ sl_strparse (const char *string, const char *delim, SLstrlist **list)
   SLstrlist *tmplist = 0;
 
   if (string != NULL && delim != NULL)
+  {
+    total = strlen (string);
+    beg   = string;
+
+    while (!stop)
     {
-      total = strlen (string);
-      beg = string;
 
-      while (!stop)
-	{
+      /* Find delimiter */
+      del = strstr (beg, delim);
 
-	  /* Find delimiter */
-	  del = strstr (beg, delim);
+      /* Delimiter not found or empty */
+      if (del == NULL || strlen (delim) == 0)
+      {
+        del  = string + strlen (string);
+        stop = 1;
+      }
 
-	  /* Delimiter not found or empty */
-	  if (del == NULL || strlen (delim) == 0)
-	    {
-	      del = string + strlen (string);
-	      stop = 1;
-	    }
+      tmplist       = (SLstrlist *)malloc (sizeof (SLstrlist));
+      tmplist->next = 0;
 
-	  tmplist = (SLstrlist *) malloc (sizeof (SLstrlist));
-	  tmplist->next = 0;
+      tmplist->element = (char *)malloc (del - beg + 1);
+      strncpy (tmplist->element, beg, (del - beg));
+      tmplist->element[(del - beg)] = '\0';
 
-	  tmplist->element = (char *) malloc (del - beg + 1);
-	  strncpy (tmplist->element, beg, (del - beg));
-	  tmplist->element[(del - beg)] = '\0';
+      /* Add this to the list */
+      if (count++ == 0)
+      {
+        curlist = tmplist;
+        *list   = curlist;
+      }
+      else
+      {
+        curlist->next = tmplist;
+        curlist       = curlist->next;
+      }
 
-	  /* Add this to the list */
-	  if (count++ == 0)
-	    {
-	      curlist = tmplist;
-	      *list = curlist;
-	    }
-	  else
-	    {
-	      curlist->next = tmplist;
-	      curlist = curlist->next;
-	    }
-
-	  /* Update 'beg' */
-	  beg = (del + strlen (delim));
-	  if ((beg - string) > total)
-	    break;
-	}
-
-      return count;
+      /* Update 'beg' */
+      beg = (del + strlen (delim));
+      if ((beg - string) > total)
+        break;
     }
+
+    return count;
+  }
   else
+  {
+    curlist = *list;
+    while (curlist != NULL)
     {
-      curlist = *list;
-      while (curlist != NULL)
-	{
-	  tmplist = curlist->next;
-	  free (curlist->element);
-	  free (curlist);
-	  curlist = tmplist;
-	}
-      *list = NULL;
-
-      return 0;
+      tmplist = curlist->next;
+      free (curlist->element);
+      free (curlist);
+      curlist = tmplist;
     }
-}  /* End of sl_strparse() */
+    *list = NULL;
 
+    return 0;
+  }
+} /* End of sl_strparse() */
 
 /***************************************************************************
  * sl_strncpclean:
@@ -113,7 +111,7 @@ sl_strparse (const char *string, const char *delim, SLstrlist **list)
  * The source string must have at least 'length' characters and the
  * destination string must have enough room needed for the non-space
  * characters within 'length' and the null terminator.
- * 
+ *
  * Returns the number of characters (not including the null terminator) in
  * the destination string.
  ***************************************************************************/
@@ -122,16 +120,16 @@ sl_strncpclean (char *dest, const char *source, int length)
 {
   int sidx, didx;
 
-  for ( sidx=0, didx=0; sidx < length ; sidx++ )
+  for (sidx = 0, didx = 0; sidx < length; sidx++)
+  {
+    if (*(source + sidx) != ' ')
     {
-      if ( *(source+sidx) != ' ' )
-	{
-	  *(dest+didx) = *(source+sidx);
-	  didx++;
-	}
+      *(dest + didx) = *(source + sidx);
+      didx++;
     }
+  }
 
-  *(dest+didx) = '\0';
+  *(dest + didx) = '\0';
 
   return didx;
-}  /* End of sl_strncpclean() */
+} /* End of sl_strncpclean() */

--- a/bin/rt/slink2orb/slink2orb.1
+++ b/bin/rt/slink2orb/slink2orb.1
@@ -1,4 +1,4 @@
-.TH SLINK2ORB 1 2012/08/31
+.TH SLINK2ORB 1 2018/08/07
 .SH NAME
 slink2orb \- SeedLink to Antelope ORB module
 .SH SYNOPSIS
@@ -57,6 +57,10 @@ and configure the SeedLink server to start with the next packet, if
 possible.  Intermediate state saves can be enabled and controlled
 with the \fIstateint\fR value in the parameter file (see below).
 
+.IP "-mbi"
+Match the byte order of integer-encoded data (16 and 32-bit) to the
+same order as the header, swapping the data payload if needed.
+
 .IP "-r"
 Use either the database specified with the -dm option or the local
 foreignkeys database to remap input net, sta, chan, and loc codes
@@ -65,11 +69,11 @@ this data with programs that do not recognize the loc code in the
 source name.
 
 .IP "-v"
-Be more verbose.  This flag can be used multiple times ("-v -v" or 
+Be more verbose.  This flag can be used multiple times ("-v -v" or
 "-vv") for more verbosity.
 
 .IP "\fISeedLink\fR"
-A required argument.  Specifies the location of the SeedLink server 
+A required argument.  Specifies the location of the SeedLink server
 in [host]:port format.  If 'host' is omitted 'localhost' is assumed.
 
 .IP "\fIORB\fR"
@@ -138,7 +142,7 @@ Equivalent to the command line version.  Any value given on the command
 line takes precedence.
 
 .IP "\fIstateint\fR"
-If this value and a \fIstatefile\fR are specified, this is the interval (in 
+If this value and a \fIstatefile\fR are specified, this is the interval (in
 seconds) at which the module will save the last valid SeedLink sequence
 number.  This can be used to protect against abnormal (power failure)
 program exits.  The default value is 0, which disables this feature.


### PR DESCRIPTION
* Update to libslink to 2.6.
* Add -mbi option to match byte order of integer encoded data to the same byte order as the miniSEED header, swapping the data payload if needed.