### PR TITLE
Fix orb2ringserver install

### DIFF
--- a/bin/rt/orb2ringserver/libdali/Makefile
+++ b/bin/rt/orb2ringserver/libdali/Makefile
@@ -73,7 +73,10 @@ clean:
 	@$(RM) $(LIB_OBJS) $(LIB_LOBJS) $(LIB_A) $(LIB_SO) $(LIB_SO_MAJOR) $(LIB_SO_BASE)
 	@echo "All clean."
 
-install: shared
+install: static
+	@echo "No install target for bundled $(LIB_A)"
+
+noinstall: shared
 	@echo "Installing into $(PREFIX)"
 	@mkdir -p $(DESTDIR)$(PREFIX)/include
 	@cp libdali.h $(DESTDIR)$(PREFIX)/include

--- a/bin/rt/orb2ringserver/libmseed/Makefile
+++ b/bin/rt/orb2ringserver/libmseed/Makefile
@@ -77,7 +77,10 @@ clean:
 	@$(MAKE) -C test clean
 	@echo "All clean."
 
-install: shared
+install: static
+	@echo "No install target for bundled $(LIB_A)"
+
+noinstall: shared
 	@echo "Installing into $(PREFIX)"
 	@mkdir -p $(DESTDIR)$(PREFIX)/include
 	@cp libmseed.h $(DESTDIR)$(PREFIX)/include


### PR DESCRIPTION
* prevent installation of bundled libmseed and libdali (only needed for static linking)