### PR TITLE
Add reject option to orb2rrdc

### DIFF
--- a/bin/rt/orb2rrdc/orb2rrdc.1
+++ b/bin/rt/orb2rrdc/orb2rrdc.1
@@ -4,7 +4,7 @@ orb2rrdc \- populate a round-robin database from an orbserver
 .SH SYNOPSIS
 .nf
 orb2rrdc [-vV] [-d cachedaemon] [-s statefile] [-p pffile] [-m match] 
-        [-f from] orb dbcache
+        [-r reject] [-f from] orb dbcache
 .fi
 .SH DESCRIPTION
 orb2rrdc enters state-of-health information from an Antelope orbserver 
@@ -41,6 +41,10 @@ option is also given (i.e. if a statefile is used).
 .IP "-m match"
 Specify a regular-expression subset of orb source-names to monitor. 
 The default is .*/pf/st.
+
+.IP "-r reject"
+Specify a regular-expression subset of orb source-names to reject.
+The default is NULL.
 
 .IP "-p pffile"
 Specify a parameter file other than the default orb2rrdc.pf

--- a/bin/rt/orb2rrdc/orb2rrdc.c
+++ b/bin/rt/orb2rrdc/orb2rrdc.c
@@ -5,682 +5,597 @@
 #include "orb.h"
 #include "brttpkt.h"
 
-Arr	*Rrd_files = 0;
-double	Status_stepsize_sec = 0;
-char	*Rrdfile_pattern = 0;
-char	*CacheDaemon = 0;
-char	*Suppress_egrep = 0;
-int	Verbose = 0;
-int 	VeryVerbose = 0;
-FILE	*Rrdfp;
+#define MAX_REGEX_LEN 200
+
+Arr *Rrd_files = 0;
+double  Status_stepsize_sec = 0;
+char    *Rrdfile_pattern = 0;
+char    *CacheDaemon = 0;
+char    *Suppress_egrep = 0;
+int Verbose = 0;
+int     VeryVerbose = 0;
+FILE    *Rrdfp;
 
 static void pfmorph( Pf *pf );
 
 static void
 usage( void )
 {
-	cbanner( "$Date$",
-		"[-vV] [-d cachedaemon] [-s statefile] [-p pffile] [-m match] [-f from]  orbname dbcache\n",
-		"Dr. Kent Lindquist",
-		"Lindquist Consulting, Inc.",
-		"kent@lindquistconsulting.com" );
+    cbanner( "$Date$",
+        "[-vV] [-d cachedaemon] [-s statefile] [-p pffile] [-m match] [-r reject] [-f from]  orbname dbcache\n",
+        "Dr. Kent Lindquist",
+        "Lindquist Consulting, Inc.",
+        "kent@lindquistconsulting.com" );
 
-	exit( 1 );
+    exit( 1 );
 }
 
 static void
 pfmorph( Pf *pf ) {
-	Pf	*dlspf = NULL;
-	Pf	*stapf = NULL;
-	Tbl	*stas = NULL;
-	int	ista;
-	char	*sta = NULL;
-	char	*opt_string = NULL;
-	char	*acok_string = NULL;
-	char	*api_string = NULL;
-	char	*isp1_string = NULL;
-	char	*isp2_string = NULL;
-	char	*ti_string = NULL;
+    Pf  *dlspf = NULL;
+    Pf  *stapf = NULL;
+    Tbl *stas = NULL;
+    int ista;
+    char    *sta = NULL;
+    char    *opt_string = NULL;
+    char    *acok_string = NULL;
+    char    *api_string = NULL;
+    char    *isp1_string = NULL;
+    char    *isp2_string = NULL;
+    char    *ti_string = NULL;
 
-	if( pfget( pf, "dls", (void **) &dlspf ) == PFINVALID ) {
+    if( pfget( pf, "dls", (void **) &dlspf ) == PFINVALID ) {
+        return;
+    }
 
-		return;
-	}
+    stas = pfkeys( dlspf );
 
-	stas = pfkeys( dlspf );
+    for( ista = 0; ista < maxtbl( stas ); ista++ ) {
+        sta = gettbl( stas, ista );
 
-	for( ista = 0; ista < maxtbl( stas ); ista++ ) {
+        if( pfget( dlspf, sta, (void **) &stapf ) == PFINVALID ) {
+            continue;
+        }
 
-		sta = gettbl( stas, ista );
+        if( ( opt_string = pfget_string( stapf, "opt" ) ) == (char *) NULL ) {
+            continue;
+        } else if( ! strcmp( opt_string, "-" ) ) {
+            if( ( acok_string = pfget_string( stapf, "acok" ) ) == (char *) NULL ) {
+                pfset( stapf, "acok", "-" );
+            }
 
-		if( pfget( dlspf, sta, (void **) &stapf ) == PFINVALID ) {
-			
-			continue;
-		}
+            if( ( api_string = pfget_string( stapf, "api" ) ) == (char *) NULL ) {
+                pfset( stapf, "api",  "-" );
+            }
 
-		if( ( opt_string = pfget_string( stapf, "opt" ) ) == (char *) NULL ) {
-			
-			continue;
+            if( ( isp1_string = pfget_string( stapf, "isp1" ) ) == (char *) NULL ) {
+                pfset( stapf, "isp1", "-" );
+            }
 
-		} else if( ! strcmp( opt_string, "-" ) ) {
+            if( ( isp2_string = pfget_string( stapf, "isp2" ) ) == (char *) NULL ) {
+                pfset( stapf, "isp2", "-" );
+            }
 
-			if( ( acok_string = pfget_string( stapf, "acok" ) ) == (char *) NULL ) {
+            if( ( ti_string = pfget_string( stapf, "ti" ) ) == (char *) NULL ) {
+                pfset( stapf, "ti",   "-" );
+            }
 
-				pfset( stapf, "acok", "-" );
-			}
+        } else {
+            if( strcontains( opt_string, "acok", NULL, NULL, NULL ) ) {
+                pfset( stapf, "acok", "1" );
+            } else {
+                pfset( stapf, "acok", "0" );
+            }
 
-			if( ( api_string = pfget_string( stapf, "api" ) ) == (char *) NULL ) {
+            if( strcontains( opt_string, "api", NULL, NULL, NULL ) ) {
+                pfset( stapf, "api", "1" );
+            } else {
+                pfset( stapf, "api", "0" );
+            }
 
-				pfset( stapf, "api",  "-" );
-			}
+            if( strcontains( opt_string, "isp1", NULL, NULL, NULL ) ) {
+                pfset( stapf, "isp1", "1" );
+            } else {
+                pfset( stapf, "isp1", "0" );
+            }
 
-			if( ( isp1_string = pfget_string( stapf, "isp1" ) ) == (char *) NULL ) {
+            if( strcontains( opt_string, "isp2", NULL, NULL, NULL ) ) {
+                pfset( stapf, "isp2", "1" );
+            } else {
+                pfset( stapf, "isp2", "0" );
+            }
+            if( strcontains( opt_string, "ti", NULL, NULL, NULL ) ) {
+                pfset( stapf, "ti", "1" );
+            } else {
+                pfset( stapf, "ti", "0" );
+            }
+        }
+    }
 
-				pfset( stapf, "isp1", "-" );
-			}
+    freetbl( stas, 0 );
 
-			if( ( isp2_string = pfget_string( stapf, "isp2" ) ) == (char *) NULL ) {
-
-				pfset( stapf, "isp2", "-" );
-			}
-
-			if( ( ti_string = pfget_string( stapf, "ti" ) ) == (char *) NULL ) {
-
-				pfset( stapf, "ti",   "-" );
-			}
-
-
-		} else {
-
-			if( strcontains( opt_string, "acok", NULL, NULL, NULL ) ) {
-
-				pfset( stapf, "acok", "1" );
-				
-			} else {
-
-				pfset( stapf, "acok", "0" );
-			}
-
-			if( strcontains( opt_string, "api", NULL, NULL, NULL ) ) {
-
-				pfset( stapf, "api", "1" );
-				
-			} else {
-
-				pfset( stapf, "api", "0" );
-			}
-
-			if( strcontains( opt_string, "isp1", NULL, NULL, NULL ) ) {
-
-				pfset( stapf, "isp1", "1" );
-				
-			} else {
-
-				pfset( stapf, "isp1", "0" );
-			}
-
-			if( strcontains( opt_string, "isp2", NULL, NULL, NULL ) ) {
-
-				pfset( stapf, "isp2", "1" );
-				
-			} else {
-
-				pfset( stapf, "isp2", "0" );
-			}
-
-			if( strcontains( opt_string, "ti", NULL, NULL, NULL ) ) {
-
-				pfset( stapf, "ti", "1" );
-				
-			} else {
-
-				pfset( stapf, "ti", "0" );
-			}
-		}
-	}
-
-	freetbl( stas, 0 );
-
-	return;
+    return;
 }
 
 static void
 archive_dlsvar( Dbptr db, char *net, char *sta, char *dls_var, char *dsparams, Tbl *rras, double time, double val )
 {
-	char	key[STRSZ];
-	char	*rrd;
-	double	start_time;
-	Dbptr	dbt;
-	char	datasource[STRSZ];
-	char	command[STRSZ];
-	char	cacheopt[FILENAME_MAX];
+    char    key[STRSZ];
+    char    *rrd;
+    double  start_time;
+    Dbptr   dbt;
+    char    datasource[STRSZ];
+    char    command[STRSZ];
+    char    cacheopt[FILENAME_MAX];
 /* Disable response printing for now (see below)
-	char	response[STRSZ];
-	char	*resp_ptr;
+    char    response[STRSZ];
+    char    *resp_ptr;
  */
-	int	i;
+    int i;
 
-	sprintf( key, "%s:%s:%s", net, sta, dls_var );
+    sprintf( key, "%s:%s:%s", net, sta, dls_var );
 
-	rrd = getarr( Rrd_files, key );
+    rrd = getarr( Rrd_files, key );
 
-/*	rrdtool in server-mode apparently does not write files until a request occurs to switch to the next
-	file, so the test below doesn't work right. Trust the database to report existing files:
- 	if( rrd == NULL || ! is_present( rrd ) ) {
+/*  rrdtool in server-mode apparently does not write files until a request occurs to switch to the next
+    file, so the test below doesn't work right. Trust the database to report existing files:
+    if( rrd == NULL || ! is_present( rrd ) ) {
 */
-	if( rrd == NULL ) {
+    if( rrd == NULL ) {
+        start_time = time - Status_stepsize_sec;
 
-		start_time = time - Status_stepsize_sec;
+        dbt = db;
+        dbt.record = dbaddnull( db );
 
-		dbt = db;
-		dbt.record = dbaddnull( db );
+        dbputv( dbt, 0, "net", net,
+                "sta", sta,
+                "rrdvar", dls_var,
+                "time", start_time,
+                NULL );
 
-		dbputv( dbt, 0, "net", net,
-				"sta", sta,
-				"rrdvar", dls_var,
-				"time", start_time,
-				NULL );
+        trwfname( dbt, Rrdfile_pattern, &rrd );
 
-		trwfname( dbt, Rrdfile_pattern, &rrd );
+        sprintf( datasource, "DS:%s:%s", dls_var, dsparams );
 
-		sprintf( datasource, "DS:%s:%s", dls_var, dsparams );
+        if( Verbose ) {
+            elog_notify( 0, "Creating rrdfile %s\n", rrd );
+        }
 
-		if( Verbose ) {
+        sprintf( command, "create %s -b %d -s %f %s", 
+            rrd, (int) floor( start_time ), Status_stepsize_sec, datasource );
 
-			elog_notify( 0, "Creating rrdfile %s\n", rrd );
-		}
+        for( i = 0; i < maxtbl( rras ); i++ ) {
+            strcat( command, " " );
+            strcat( command, (char *) gettbl( rras, i ) );
+        }
 
-		sprintf( command, "create %s -b %d -s %f %s", 
-			rrd, (int) floor( start_time ), Status_stepsize_sec, datasource );
+        if( VeryVerbose ) {
+            elog_notify( 0, "Issuing rrdtool command: '%s'\n", command );
+        }
+        fprintf( Rrdfp, "%s\n", command );
 
-		for( i = 0; i < maxtbl( rras ); i++ ) {
+        /* Disable response printing for now since popen() bi-directional pipes 
+           are not supported across all platforms: 
 
-			strcat( command, " " );
-			strcat( command, (char *) gettbl( rras, i ) );
-		}
+        if( VeryVerbose ) { 
 
-		if( VeryVerbose ) {
-			
-			elog_notify( 0, "Issuing rrdtool command: '%s'\n", command );
-		}
-	
-		fprintf( Rrdfp, "%s\n", command );
+            resp_ptr = getaline( Rrdfp, response, STRSZ );
 
-		/* Disable response printing for now since popen() bi-directional pipes 
-		   are not supported across all platforms: 
+            if( resp_ptr == (char *) NULL ) {
 
-		if( VeryVerbose ) { 
+                elog_notify( 0, "%s\n", "(null)" );
 
-			resp_ptr = getaline( Rrdfp, response, STRSZ );
+            } else {
 
-			if( resp_ptr == (char *) NULL ) {
+                elog_notify( 0, "%s\n", resp_ptr );
+            }
+        }
+        */
 
-				elog_notify( 0, "%s\n", "(null)" );
+        setarr( Rrd_files, key, strdup( rrd ) );
+    }
 
-			} else {
+    if( VeryVerbose ) {
+        elog_notify( 0, "Recording time '%f' value '%f' from '%s:%s:%s' in '%s'\n",
+            time, val, net, sta, dls_var, rrd );
+    }
 
-				elog_notify( 0, "%s\n", resp_ptr );
-			}
-		}
-		*/
+    if( CacheDaemon == NULL ) {
+        sprintf( cacheopt, "%s", "" );
+    } else {
+        sprintf( cacheopt, "--daemon=%s", CacheDaemon );
+    }
 
-		setarr( Rrd_files, key, strdup( rrd ) );
-	}
+    sprintf( command, "update %s %s %d:%f", cacheopt, rrd, (int) floor( time ), val );
 
-	if( VeryVerbose ) {
+    if( VeryVerbose ) {
+        elog_notify( 0, "Issuing rrdtool command: '%s'\n", command );
+    }
 
-		elog_notify( 0, "Recording time '%f' value '%f' from '%s:%s:%s' in '%s'\n",
-			time, val, net, sta, dls_var, rrd );
-	}
+    fprintf( Rrdfp, "%s\n", command );
 
-	if( CacheDaemon == NULL ) {
+    /* Disable response printing for now since popen() bi-directional pipes 
+       are not supported across all platforms: 
 
-		sprintf( cacheopt, "%s", "" );
+    if( VeryVerbose ) { 
 
-	} else {
+        resp_ptr = getaline( Rrdfp, response, STRSZ );
 
-		sprintf( cacheopt, "--daemon=%s", CacheDaemon );
+        if( resp_ptr == (char *) NULL ) {
 
-	}
+            elog_notify( 0, "%s\n", "(null)" );
 
-	sprintf( command, "update %s %s %d:%f", cacheopt, rrd, (int) floor( time ), val );
+        } else {
 
-	if( VeryVerbose ) {
-			
-		elog_notify( 0, "Issuing rrdtool command: '%s'\n", command );
-	}
-	
-	fprintf( Rrdfp, "%s\n", command );
-
-	/* Disable response printing for now since popen() bi-directional pipes 
-	   are not supported across all platforms: 
-
-	if( VeryVerbose ) { 
-
-		resp_ptr = getaline( Rrdfp, response, STRSZ );
-
-		if( resp_ptr == (char *) NULL ) {
-
-			elog_notify( 0, "%s\n", "(null)" );
-
-		} else {
-
-			elog_notify( 0, "%s\n", resp_ptr );
-		}
-	}
-	*/
+            elog_notify( 0, "%s\n", resp_ptr );
+        }
+    }
+    */
 }
 
 int
 main( int argc, char **argv )
 {
-	int	c;
-	int	errflag = 0;
-	int	orb;
-	int	stop = 0;
-	long	nrecs;
-	char	*match = ".*/pf/st";
-	char	*from = 0;
-	char	*statefile = 0;
-	char	*pfname = "orb2rrdc";
-	char	*orbname;
-	char	*dbcache;
-	char	*rrdtool;
-	char	command[STRSZ];
-	char	net[STRSZ];
-	char	sta[STRSZ];
-	char	rrdvar[STRSZ];
-	char	key[STRSZ];
-	char	path[FILENAME_MAX];
-	Dbptr	db;
-	Dbptr	dbt;
-	Pf	*pf;
-	char	*Default_network;
-	Tbl	*dlslines;
-	Arr	*Dls_vars_dsparams;
-	Arr	*Dls_vars_rras;
-	Tbl	*Dls_vars_keys;
-	char	*line;
-	char	*dls_var;
-	char	*dsparams;
-	Tbl	*rras;
-	int	i;
-	int	j;
-	OrbreapThr *ort;
-	int	pktid;
-	char	srcname[ORBSRCNAME_SIZE];
-	double	time = 0;
-	char	*packet = 0;
-	int	nbytes = 0;
-	int	bufsize = 0;
-	Packet	*pkt = 0;
-	int	rc;
-	char	*s;
-	Pf	*dlspf;
-	Tbl	*dlspfkeys;
-	char	*element;
-	Tbl	*parts;
-	double	val;
-	Pf	*pfval = 0;
-
-	elog_init( argc, argv );
-
-	while( ( c = getopt( argc, argv, "vVd:s:p:m:f:" ) ) != -1 ) {
-
-		switch( c ) {
-
-		case 'd':
-			CacheDaemon = optarg;
-			break;
-
-		case 'f':
-			from = optarg;
-			break;
-
-		case 'm':
-			match = optarg;
-			break;
-
-		case 'p': 
-			pfname = optarg;
-			break;
-
-		case 's':
-			statefile = optarg;
-			break;
-			
-		case 'v':
-			Verbose++;
-			break;
+    int c;
+    int errflag = 0;
+    int orb;
+    int stop = 0;
+    long nrecs;
+    char *match = ".*/pf/st";
+    char *reject = NULL;
+    char *from = 0;
+    char *statefile = 0;
+    char *pfname = "orb2rrdc";
+    char *orbname;
+    char *dbcache;
+    char *rrdtool;
+    char command[STRSZ];
+    char net[STRSZ];
+    char sta[STRSZ];
+    char rrdvar[STRSZ];
+    char key[STRSZ];
+    char path[FILENAME_MAX];
+    Dbptr db;
+    Dbptr dbt;
+    Pf *pf;
+    char *Default_network;
+    Tbl *dlslines;
+    Arr *Dls_vars_dsparams;
+    Arr *Dls_vars_rras;
+    Tbl *Dls_vars_keys;
+    unsigned char *line;
+    char *dls_var;
+    char *dsparams;
+    Tbl *rras;
+    int i;
+    int j;
+    OrbreapThr *ort;
+    int pktid;
+    char srcname[ORBSRCNAME_SIZE];
+    double time = 0;
+    char *packet = 0;
+    int nbytes = 0;
+    int bufsize = 0;
+    Packet *pkt = 0;
+    int rc;
+    char *s;
+    Pf *dlspf;
+    Tbl *dlspfkeys;
+    char *element;
+    Tbl *parts;
+    double val;
+    Pf *pfval = 0;
+
+    elog_init( argc, argv );
+
+    while( ( c = getopt( argc, argv, "vVd:s:p:m:r:f:" ) ) != -1 ) {
+        switch( c ) {
+        case 'd':
+            CacheDaemon = optarg;
+            break;
+        case 'f':
+            from = optarg;
+            break;
+        case 'm':
+            match = optarg;
+            break;
+        case 'r':
+            reject = optarg;
+            break;
+        case 'p': 
+            pfname = optarg;
+            break;
+        case 's':
+            statefile = optarg;
+            break;
+        case 'v':
+            Verbose++;
+            break;
+        case 'V':
+            VeryVerbose++;
+            Verbose++;
+            break;
+        default:
+            elog_complain( 0, "Unknown option '%c'\n", c );
+            errflag++;
+            break;
+        }
+    }
+
+    if( errflag || argc - optind != 2 ) {
+        usage();
+    }
+
+    if( Verbose ) {
+        elog_notify( 0, "Starting at %s (%s $Revision$ $Date$)\n", 
+                zepoch2str( str2epoch( "now" ), "%D %T %Z", "" ),
+                Program_Name );
+    }
+
+    orbname = argv[optind++];
+    dbcache = argv[optind++];
+
+    pfread( pfname, &pf );
+
+    rrdtool = pfget_string( pf, "rrdtool" );
 
-		case 'V':
-			VeryVerbose++;
-			Verbose++;
-			break;
-		
-		default:
-			elog_complain( 0, "Unknown option '%c'\n", c );
-			errflag++;
-			break;
-		}
-	}
+    if( rrdtool == NULL || ! strcmp( rrdtool, "" ) ) {
+        elog_die( 0, "Error: no rrdtool executable name specified in parameter file\n" );
 
-	if( errflag || argc - optind != 2 ) {
+    } else if( ( rrdtool[0] == '/' && ! is_present( rrdtool ) ) || ( rrdtool[0] != '/' && ! datafile( "PATH", rrdtool ) ) ) {
+        elog_die( 0, "Error: can't find rrdtool executable by name of '%s' (check PATH environment " 
+            "variable, or absolute path name if given)\n", rrdtool );
 
-		usage();
-	}
+    } else if( rrdtool[0] == '/' ) {
+        sprintf( command, "%s -", rrdtool );
 
-	if( Verbose ) {
+    } else {
+        sprintf( command, "rrdtool -" );
+    }
 
-		elog_notify( 0, "Starting at %s (%s $Revision$ $Date$)\n", 
-				zepoch2str( str2epoch( "now" ), "%D %T %Z", "" ),
-				Program_Name );
-	}
+    Suppress_egrep = pfget_string( pf, "suppress_egrep" );
 
-	orbname = argv[optind++];
-	dbcache = argv[optind++];
+    if( Suppress_egrep != NULL && strcmp( Suppress_egrep, "" ) ) {
+        if( ! datafile( "PATH", "egrep" ) ) {
+            elog_complain( 0, "Ignoring suppress_egrep parameter: can't find egrep on path\n" ); 
+        } else {
+            sprintf( command, "%s 2>&1 | egrep -v '%s'", command, Suppress_egrep );
+        }
+    }
 
-	pfread( pfname, &pf );
+    if( VeryVerbose ) {
+        elog_notify( 0, "Executing command: %s\n", command );
+    }
 
-	rrdtool = pfget_string( pf, "rrdtool" );
+    Rrdfp = popen( command, "w" );
 
-	if( rrdtool == NULL || ! strcmp( rrdtool, "" ) ) {
+    if( Rrdfp == (FILE *) NULL ) {
+        elog_die( 0, "Failed to open socket to rrdtool command\n" );
+    }
 
-		elog_die( 0, "Error: no rrdtool executable name specified in parameter file\n" );
+    orb = orbopen( orbname, "r&" );
 
-	} else if( ( rrdtool[0] == '/' && ! is_present( rrdtool ) ) || ( rrdtool[0] != '/' && ! datafile( "PATH", rrdtool ) ) ) {
+    if( orb < 0 ) {
+        elog_die( 0, "Failed to open orb '%s' for reading. Bye.\n", orbname );
+    }
 
-		elog_die( 0, "Error: can't find rrdtool executable by name of '%s' (check PATH environment " 
-			"variable, or absolute path name if given)\n", rrdtool );
+    orbselect( orb, match );
 
-	} else if( rrdtool[0] == '/' ) {
+    if ( reject && ( strnlen( reject, MAX_REGEX_LEN ) ) > 0 ) {
+        orbreject( orb, reject );
+    }
 
-		sprintf( command, "%s -", rrdtool );
+    if( from != NULL && statefile == NULL ) {
+        pktid = orbposition( orb, from );
+        if( Verbose ) {
+            elog_notify( 0, "Positioned to packet %d\n", pktid );
+        }
 
-	} else {
+    } else if( from != NULL ) {
+        elog_complain( 0, "Ignoring -f in favor of existing state file\n" );
+    }
 
-		sprintf( command, "rrdtool -" );
-	}
+    if( statefile != NULL ) {
+        stop = 0;
 
-	Suppress_egrep = pfget_string( pf, "suppress_egrep" );
+        exhume( statefile, &stop, 15, 0 );
 
-	if( Suppress_egrep != NULL && strcmp( Suppress_egrep, "" ) ) {
-		
-		if( ! datafile( "PATH", "egrep" ) ) {
+        orbresurrect( orb, &pktid, &time );
 
-			elog_complain( 0, "Ignoring suppress_egrep parameter: can't find egrep on path\n" ); 
+        if( Verbose ) {
+            elog_notify( 0, "Resurrecting state to pktid %d, time %s\n",
+                pktid, s = strtime( time ) );
+            free( s );
+        }
 
-		} else {
+        orbseek( orb, pktid );
+    }
 
-			sprintf( command, "%s 2>&1 | egrep -v '%s'", command, Suppress_egrep );
-		}
-	}
+    dbopen( dbcache, "r+", &db );
 
-	if( VeryVerbose ) {
+    if( db.database < 0 ) {
+        elog_die( 0, "Failed to open cache database '%s'. Bye.\n", dbcache );
 
-		elog_notify( 0, "Executing command: %s\n", command );
-	}
+    } else {
+        db = dblookup( db, "", "rrdcache", "", "" );
 
-	Rrdfp = popen( command, "w" );
+        if( db.table < 0 ) {
+            elog_die( 0, "Failed to lookup 'rrdcache' table in '%s'. Bye.\n", dbcache );
+        }
+    }
 
-	if( Rrdfp == (FILE *) NULL ) {
+    dbcrunch( db );
 
-		elog_die( 0, "Failed to open socket to rrdtool command\n" );
-	}
+    dbt = dbsubset( db, "endtime == NULL", NULL );
 
-	orb = orbopen( orbname, "r&" );
+    Rrd_files = newarr( 0 );
 
-	if( orb < 0 ) {
+    dbquery( dbt, dbRECORD_COUNT, &nrecs );
 
-		elog_die( 0, "Failed to open orb '%s' for reading. Bye.\n", orbname );
-	}
+    for( dbt.record = 0; dbt.record < nrecs; dbt.record++ ) {
+        dbgetv( dbt, 0, "net", &net, "sta", &sta, "rrdvar", &rrdvar, NULL );
 
-	orbselect( orb, match );
+        dbfilename( dbt, (char *) &path );
 
-	if( from != NULL && statefile == NULL ) {
+        sprintf( key, "%s:%s:%s", net, sta, rrdvar );
 
-		pktid = orbposition( orb, from );
+        if( ! is_present( path ) ) {
+            elog_complain( 0, "WARNING: rrd file '%s', listed in database, does not exist. "
+                "Removing database entry.\n", path );
 
-		if( Verbose ) {
+            dbmark( dbt );
 
-			elog_notify( 0, "Positioned to packet %d\n", pktid );
-		}
+        } else {
+            setarr( Rrd_files, key, strdup( path ) );
 
-	} else if( from != NULL ) {
+            if( VeryVerbose ) {
+                elog_notify( 0, "Re-using rrd file '%s' for '%s'\n", path, key );
+            }
+        }
+    }
 
-		elog_complain( 0, "Ignoring -f in favor of existing state file\n" );
-	}
+    Rrdfile_pattern = pfget_string( pf, "rrdfile_pattern" );
+    Status_stepsize_sec = pfget_double( pf, "status_stepsize_sec" );
+    Default_network = pfget_string( pf, "default_network" );
+    dlslines = pfget_tbl( pf, "dls_vars" );
 
-	if( statefile != NULL ) {
+    Dls_vars_dsparams = newarr( 0 );
+    Dls_vars_rras = newarr( 0 );
 
-		stop = 0;
+    for( i = 0; i < maxtbl( dlslines ); i++ ) {
+        line = gettbl( dlslines, i );
 
-		exhume( statefile, &stop, 15, 0 );
+        strtr( line, (unsigned const char*) "\t", (unsigned const char*) " " );
+        rras = split( (char*) line, ' ' );
 
-		orbresurrect( orb, &pktid, &time );
+        dls_var = shifttbl( rras );
+        dsparams = shifttbl( rras );
 
-		if( Verbose ) {
+        setarr( Dls_vars_dsparams, dls_var, dsparams );
+        setarr( Dls_vars_rras, dls_var, rras );
+    }
 
-			elog_notify( 0, "Resurrecting state to pktid %d, time %s\n",
-				pktid, s = strtime( time ) );
+    ort = orbreapthr_new( orb, -1., 0 );
 
-			free( s );
-		}
+    while ( 1 ) {
+        orbreapthr_get( ort, &pktid, srcname, &time, &packet, &nbytes, &bufsize );
 
-		orbseek( orb, pktid );
-	}
+        if( statefile ) {
+            rc = bury();
 
-	dbopen( dbcache, "r+", &db );
+            if( rc < 0 ) {
+                elog_complain( 0, "Unexpected failure of bury command! " 
+                    "(are there two orb2rrdc's running with the same state" 
+                    "file?)\n" );
 
-	if( db.database < 0 ) {
-		
-		elog_die( 0, "Failed to open cache database '%s'. Bye.\n", dbcache );
+                elog_clear_register( 1 );
+            }
+        }
 
-	} else {
-		
-		db = dblookup( db, "", "rrdcache", "", "" );
+        rc = unstuffPkt( srcname, time, packet, nbytes, &pkt );
 
-		if( db.table < 0 ) {
+        if( rc == Pkt_pf ) {
+            if( VeryVerbose ) {
+                /* Parameter files generally too big for elog */
+                fprintf( stderr, "Received a parameter-file '%s' at %s\n%s\n\n", 
+                        srcname, 
+                        s = strtime( time ), 
+                        pf2string( pkt->pf ) );
 
-			elog_die( 0, "Failed to lookup 'rrdcache' table in '%s'. Bye.\n", dbcache );
-		}
-	}
+                free( s );
 
-	dbcrunch( db );
+            } else if( Verbose ) {
+                elog_notify( 0, "Received a parameter-file '%s' at %s\n", 
+                        srcname, s = strtime( time ) );
 
-	dbt = dbsubset( db, "endtime == NULL", NULL );
+                free( s );
+            }
 
-	Rrd_files = newarr( 0 );
+            pfmorph( pkt->pf );
 
-	dbquery( dbt, dbRECORD_COUNT, &nrecs );
+            if( VeryVerbose ) {
+                fprintf( stderr, "Morphed parameter-file '%s' to interpret 'opt':\n%s\n\n", 
+                        srcname, 
+                        pf2string( pkt->pf ) );
+            }
 
-	for( dbt.record = 0; dbt.record < nrecs; dbt.record++ ) {
+            pfget( pkt->pf, "dls", (void **) &dlspf );
 
-		dbgetv( dbt, 0, "net", &net, "sta", &sta, "rrdvar", &rrdvar, NULL );
+            dlspfkeys = pfkeys( dlspf );
+            Dls_vars_keys = keysarr( Dls_vars_dsparams );
 
-		dbfilename( dbt, (char *) &path );
+            for( i = 0; i < maxtbl( dlspfkeys ); i++ ) {
+               element = gettbl( dlspfkeys, i );
 
-		sprintf( key, "%s:%s:%s", net, sta, rrdvar );
+               if( strcontains( element, "_", 0, 0, 0 ) ) {
+                   parts = split( (s = strdup( element )), '_' );
 
-		if( ! is_present( path ) ) {
-			
-			elog_complain( 0, "WARNING: rrd file '%s', listed in database, does not exist. "
-				"Removing database entry.\n", path );
+                   sprintf( net, "%s", (char *) gettbl( parts, 0 ) );
+                   sprintf( sta, "%s", (char *) gettbl( parts, 1 ) );
 
-			dbmark( dbt );
+                   free( s );
+                   freetbl( parts, 0 );
+               } else {
+                   sprintf( net, "%s", Default_network );
+                   sprintf( sta, "%s", element );
+               }
 
-		} else {
+               for( j = 0; j < maxtbl( Dls_vars_keys ); j++ ) {
+                dls_var = gettbl( Dls_vars_keys, j );
 
-			setarr( Rrd_files, key, strdup( path ) );
+                sprintf( key, "%s{%s}", element, dls_var );
 
-			if( VeryVerbose ) {
+                if( pfresolve( dlspf, key, 0, &pfval ) < 0 ) {
 
-				elog_notify( 0, "Re-using rrd file '%s' for '%s'\n", path, key );
-			}
-		}
-	}
+                    elog_complain( 0, "Unable to extract variable '%s' "
+                        "(not present or wrong type) from element '%s' "
+                        "in packet from '%s', timestamped '%s'; Skipping\n",
+                        key, element, srcname, s = strtime( time ) );
 
-	Rrdfile_pattern = pfget_string( pf, "rrdfile_pattern" );
-	Status_stepsize_sec = pfget_double( pf, "status_stepsize_sec" );
-	Default_network = pfget_string( pf, "default_network" );
-	dlslines = pfget_tbl( pf, "dls_vars" );
+                    free( s );
 
-	Dls_vars_dsparams = newarr( 0 );
-	Dls_vars_rras = newarr( 0 );
+                    pfval = 0;
 
-	for( i = 0; i < maxtbl( dlslines ); i++ ) {
-		
-		line = gettbl( dlslines, i );
-		
-		strtr( line, "\t", " " );
-		rras = split( line, ' ' );
+                    continue;
 
-		dls_var = shifttbl( rras );
-		dsparams = shifttbl( rras );
+                } else if( pfval != (Pf *) NULL &&
+                       pfval->value.s != (char *) NULL &&
+                       ! strcmp( pfval->value.s, "-" ) ) {
 
-		setarr( Dls_vars_dsparams, dls_var, dsparams );
-		setarr( Dls_vars_rras, dls_var, rras );
-	}
+                    if( VeryVerbose ) {
 
-	ort = orbreapthr_new( orb, -1., 0 );
+                        elog_notify( 0, "Non-floating point value '-' in variable '%s', "
+                            "in packet from '%s', timestamped '%s'; Skipping data point\n",
+                            key, srcname, s = strtime( time ) );
 
-	for( ; stop == 0; ) {
+                        free( s );
+                    }
 
-		orbreapthr_get( ort, &pktid, srcname, &time, &packet, &nbytes, &bufsize );
+                    continue;
+                } else {
+                    val = pfget_double( dlspf, key );
+                }
 
-		if( statefile ) {
+                archive_dlsvar( db, net, sta, dls_var, 
+                        (char *) getarr( Dls_vars_dsparams, dls_var ),
+                        (Tbl *) getarr( Dls_vars_rras, dls_var ),
+                        time, val );
+               }
 
-			rc = bury();
+            }
 
-			if( rc < 0 ) {
+            freetbl( dlspfkeys, 0 );
+            freetbl( Dls_vars_keys, 0 );
 
-				elog_complain( 0, "Unexpected failure of bury command! " 
-					"(are there two orb2rrdc's running with the same state" 
-					"file?)\n" );
+        } else if( rc == Pkt_stash ) {
+            ; /* Do nothing */
 
-				elog_clear_register( 1 );
-			}
-		}
-
-		rc = unstuffPkt( srcname, time, packet, nbytes, &pkt );
-
-		if( rc == Pkt_pf ) {
-
-			if( VeryVerbose ) {
-
-				/* Parameter files generally too big for elog */
-
-				fprintf( stderr, "Received a parameter-file '%s' at %s\n%s\n\n", 
-						srcname, 
-						s = strtime( time ), 
-						pf2string( pkt->pf ) );
-
-				free( s );
-
-			} else if( Verbose ) {
-
-				elog_notify( 0, "Received a parameter-file '%s' at %s\n", 
-						srcname, s = strtime( time ) );
-
-				free( s );
-			}
-
-			pfmorph( pkt->pf );
-
-			if( VeryVerbose ) {
-
-				fprintf( stderr, "Morphed parameter-file '%s' to interpret 'opt':\n%s\n\n", 
-						srcname, 
-						pf2string( pkt->pf ) );
-			}
-
-			pfget( pkt->pf, "dls", (void **) &dlspf );
-
-			dlspfkeys = pfkeys( dlspf );
-			Dls_vars_keys = keysarr( Dls_vars_dsparams );
-
-			for( i = 0; i < maxtbl( dlspfkeys ); i++ ) {
-			   
-			   element = gettbl( dlspfkeys, i );
-
-			   if( strcontains( element, "_", 0, 0, 0 ) ) {
-
-				parts = split( (s = strdup( element )), '_' );
-
-				sprintf( net, "%s", (char *) gettbl( parts, 0 ) );
-				sprintf( sta, "%s", (char *) gettbl( parts, 1 ) );
-
-				free( s );
-				freetbl( parts, 0 );
-
-			   } else {
-
-				sprintf( net, "%s", Default_network );
-
-				sprintf( sta, "%s", element );
-			   }
-
-			   for( j = 0; j < maxtbl( Dls_vars_keys ); j++ ) {
-
-			   	dls_var = gettbl( Dls_vars_keys, j );
-
-				sprintf( key, "%s{%s}", element, dls_var );
-
-				if( pfresolve( dlspf, key, 0, &pfval ) < 0 ) {
-
-					elog_complain( 0, "Unable to extract variable '%s' "
-						"(not present or wrong type) from element '%s' "
-						"in packet from '%s', timestamped '%s'; Skipping\n",
-						key, element, srcname, s = strtime( time ) );
-
-					free( s );
-
-					pfval = 0;
-
-					continue;
-
-				} else if( pfval != (Pf *) NULL &&
-					   pfval->value.s != (char *) NULL &&
-					   ! strcmp( pfval->value.s, "-" ) ) {
-
-					if( VeryVerbose ) {
-
-						elog_notify( 0, "Non-floating point value '-' in variable '%s', "
-							"in packet from '%s', timestamped '%s'; Skipping data point\n",
-							key, srcname, s = strtime( time ) );
-
-						free( s );
-					}
-
-					continue;
-
-				} else {
-
-					val = pfget_double( dlspf, key );
-				}
-
-				archive_dlsvar( db, net, sta, dls_var, 
-						(char *) getarr( Dls_vars_dsparams, dls_var ),
-						(Tbl *) getarr( Dls_vars_rras, dls_var ),
-						time, val );
-			   }
-
-			}
-
-			freetbl( dlspfkeys, 0 );
-			freetbl( Dls_vars_keys, 0 );
-
-		} else if( rc == Pkt_stash ) {
-
-			; /* Do nothing */
-
-		} else {
-
-			if( Verbose ) {
-
-				elog_notify( 0, "Received a packet that's not a parameter file " 
-					"(type '%d' from unstuffPkt); skipping\n", rc );
-			}
-		}
-	}
+        } else {
+            if( Verbose ) {
+                elog_notify( 0, "Received a packet that's not a parameter file " 
+                    "(type '%d' from unstuffPkt); skipping\n", rc );
+            }
+        }
+    }
 }
+/* vim: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
orb2rrdc is incredibly verbose when it encounters packets it doesn't like. Running it on a not quite clean orb causes disks to fill with log messages. This change adds a reject option similar to other programs. Additionally, it refactors the code to clean up whitespace.